### PR TITLE
[DOP-14025] Fix patching connection with new auth_data.password value

### DIFF
--- a/docs/changelog/next_release/39.bugfix.rst
+++ b/docs/changelog/next_release/39.bugfix.rst
@@ -1,0 +1,1 @@
+Fix 500 error in case of ``PATCH v1/connections/:id`` request with passed ``auth_data.password`` field value

--- a/syncmaster/db/repositories/connection.py
+++ b/syncmaster/db/repositories/connection.py
@@ -81,19 +81,19 @@ class ConnectionRepository(RepositoryWithOwner[Connection]):
         connection_id: int,
         name: str | None,
         description: str | None,
-        connection_data: dict[str, Any],
+        data: dict[str, Any],
     ) -> Connection:
         try:
             connection = await self.read_by_id(connection_id=connection_id)
             for key in connection.data:
-                if key not in connection_data or connection_data[key] is None:
-                    connection_data[key] = connection.data[key]
+                data[key] = data.get(key, None) or connection.data[key]
+
             return await self._update(
                 Connection.id == connection_id,
                 Connection.is_deleted.is_(False),
                 name=name or connection.name,
                 description=description or connection.description,
-                data=connection_data,
+                data=data,
             )
         except IntegrityError as e:
             self._raise_error(e)

--- a/syncmaster/db/repositories/credentials_repository.py
+++ b/syncmaster/db/repositories/credentials_repository.py
@@ -65,17 +65,15 @@ class CredentialsRepository(Repository[AuthData]):
     async def update(
         self,
         connection_id: int,
-        credential_data: dict,
+        data: dict,
     ) -> AuthData:
         creds = await self.read(connection_id)
         try:
             for key in creds:
-                if key not in credential_data or credential_data[key] is None:
-                    credential_data[key] = creds[key]
-
+                data[key] = data.get(key, None) or creds[key]
             return await self._update(
                 AuthData.connection_id == connection_id,
-                value=encrypt_auth_data(value=credential_data, settings=self._settings),
+                value=encrypt_auth_data(value=data, settings=self._settings),
             )
         except IntegrityError as e:
             self._raise_error(e)

--- a/syncmaster/db/repositories/utils.py
+++ b/syncmaster/db/repositories/utils.py
@@ -3,6 +3,7 @@
 import json
 
 from cryptography.fernet import Fernet
+from pydantic import SecretStr
 
 from syncmaster.config import Settings
 
@@ -11,15 +12,26 @@ def decrypt_auth_data(
     value: str,
     settings: Settings,
 ) -> dict:
-    f = Fernet(settings.CRYPTO_KEY)
-    return json.loads(f.decrypt(value))
+    decryptor = Fernet(settings.CRYPTO_KEY)
+    decrypted = decryptor.decrypt(value)
+    return json.loads(decrypted)
+
+
+def _json_default(value):
+    if isinstance(value, SecretStr):
+        return value.get_secret_value()
 
 
 def encrypt_auth_data(
     value: dict,
     settings: Settings,
 ) -> str:
-    key = str.encode(settings.CRYPTO_KEY)
-    f = Fernet(key)
-    token = f.encrypt(str.encode(json.dumps(value)))
-    return token.decode(encoding="utf-8")
+    encryptor = Fernet(settings.CRYPTO_KEY)
+    serialized = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        default=_json_default,
+    )
+    encrypted = encryptor.encrypt(serialized.encode("utf-8"))
+    return encrypted.decode("utf-8")

--- a/tests/test_unit/test_connections/test_update_connection.py
+++ b/tests/test_unit/test_connections/test_update_connection.py
@@ -209,7 +209,42 @@ async def test_update_connection_data_fields(
     assert result.status_code == 200
 
 
-async def test_update_connection_auth_data_fields(
+async def test_update_connection_auth_data_all_felds(
+    client: AsyncClient,
+    group_connection: MockConnection,
+    role_developer_plus: UserTestRoles,
+):
+    # Arrange
+    user = group_connection.owner_group.get_member_of_role(role_developer_plus)
+    # Act
+    result = await client.patch(
+        f"v1/connections/{group_connection.id}",
+        headers={"Authorization": f"Bearer {user.token}"},
+        json={"auth_data": {"type": "postgres", "user": "new_user", "password": "new_password"}},
+    )
+
+    # Assert
+    assert result.json() == {
+        "id": group_connection.id,
+        "name": group_connection.name,
+        "description": group_connection.description,
+        "group_id": group_connection.group_id,
+        "connection_data": {
+            "type": group_connection.data["type"],
+            "host": "127.0.0.1",
+            "port": group_connection.data["port"],
+            "additional_params": group_connection.data["additional_params"],
+            "database_name": group_connection.data["database_name"],
+        },
+        "auth_data": {
+            "type": group_connection.credentials.value["type"],
+            "user": "new_user",
+        },
+    }
+    assert result.status_code == 200
+
+
+async def test_update_connection_auth_data_partial(
     client: AsyncClient,
     group_connection: MockConnection,
     role_developer_plus: UserTestRoles,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Fixed bug when sending `PATCH v1/connections/:id` request with new `auth_data.password` value returned 500 error with traceback:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/uvicorn/protocols/http/h11_impl.py", line 407, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 69, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/applications.py", line 123, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/cors.py", line 85, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 65, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 756, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 776, in app
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 297, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 77, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 72, in app
    response = await func(request)
               ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", line 278, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", line 191, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/syncmaster/backend/api/v1/connections.py", line 204, in update_connection
    await unit_of_work.credentials.update(
  File "/app/syncmaster/db/repositories/credentials_repository.py", line 81, in update
    value=encrypt_auth_data(value=credential_data, settings=self._settings),
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/syncmaster/db/repositories/utils.py", line 24, in encrypt_auth_data
    token = f.encrypt(str.encode(json.dumps(value)))
                                 ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type SecretStr is not JSON serializable

```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.