### PR TITLE
[DOP-14025] Remove asyncio.gather from SQLAlchemy requests

### DIFF
--- a/docs/changelog/next_release/40.bugfix.rst
+++ b/docs/changelog/next_release/40.bugfix.rst
@@ -1,0 +1,1 @@
+Do not use ``asyncio.gather`` with SQLAlchemy requests.

--- a/syncmaster/db/repositories/credentials_repository.py
+++ b/syncmaster/db/repositories/credentials_repository.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import NoReturn
 
-from sqlalchemy import ScalarResult, delete, insert, select
+from sqlalchemy import ScalarResult, insert, select
 from sqlalchemy.exc import DBAPIError, IntegrityError, NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -26,7 +26,7 @@ class CredentialsRepository(Repository[AuthData]):
         super().__init__(model=model, session=session)
         self._settings = settings
 
-    async def get_for_connection(
+    async def read(
         self,
         connection_id: int,
     ) -> dict:
@@ -37,7 +37,15 @@ class CredentialsRepository(Repository[AuthData]):
         except NoResultFound as e:
             raise AuthDataNotFoundError(f"Connection id = {connection_id}") from e
 
-    async def add_to_connection(self, connection_id: int, data: dict) -> AuthData:
+    async def read_bulk(
+        self,
+        connection_ids: list[int],
+    ) -> dict[int, dict]:
+        query = select(AuthData).where(AuthData.connection_id.in_(connection_ids))
+        result: ScalarResult[AuthData] = await self._session.scalars(query)
+        return {item.connection_id: decrypt_auth_data(item.value, settings=self._settings) for item in result}
+
+    async def create(self, connection_id: int, data: dict) -> AuthData:
         query = (
             insert(AuthData)
             .values(
@@ -54,23 +62,12 @@ class CredentialsRepository(Repository[AuthData]):
             await self._session.flush()
             return result.one()
 
-    async def delete_from_connection(self, connection_id: int) -> AuthData:
-        query = delete(AuthData).where(AuthData.connection_id == connection_id).returning(AuthData)
-
-        try:
-            result: ScalarResult[AuthData] = await self._session.scalars(query)
-        except IntegrityError as e:
-            self._raise_error(e)
-        else:
-            await self._session.flush()
-            return result.one()
-
     async def update(
         self,
         connection_id: int,
         credential_data: dict,
     ) -> AuthData:
-        creds = await self.get_for_connection(connection_id)
+        creds = await self.read(connection_id)
         try:
             for key in creds:
                 if key not in credential_data or credential_data[key] is None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Using `asyncio.gather` with SQLAlchemy may result some unexpected errors: https://github.com/sqlalchemy/sqlalchemy/discussions/9312. We should avoid using it.

Also even `asyncio.gather` is still expensive because each `for loop` iteration sends a separated query to the database. Replaced it with `connection_id IN (...)` clause, reducing to just one database request.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.