### PR TITLE
[DOP-14025] Add workflow for cleanup CI cache

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,40 @@
+name: Cleanup caches after merge
+on:
+  pull_request:
+    types:
+      - closed
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      # `actions:write` permission is required to delete caches
+      #  See also: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#delete-a-github-actions-cache-for-a-repository-using-a-cache-id
+      actions: write
+      contents: read
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Cleanup cache
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          REPO=${{ github.repository }}
+          BRANCH=refs/pull/${{ github.event.pull_request.number }}/merge
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH --limit 100 --sort size | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,8 +50,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-codeql-${{ hashFiles('**/poetry.lock') }}
             ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-codeql-
-            ${{ runner.os }}-python
-            ${{ runner.os }}-
+            ${{ runner.os }}-python-
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/hdfs-tests.yml
+++ b/.github/workflows/hdfs-tests.yml
@@ -24,11 +24,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ./cached_jars
-          key: ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-hdfs-jars
+          key: ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-jars
           restore-keys: |
-            ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-hdfs-jars
-            ${{ runner.os }}-python
-            ${{ runner.os }}
+            ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-jars
+            ${{ runner.os }}-python-
 
       - name: Build Worker Image
         uses: docker/build-push-action@v5

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -24,11 +24,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ./cached_jars
-          key: ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-hive-jars
+          key: ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-jars
           restore-keys: |
-            ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-hive-jars
-            ${{ runner.os }}-python
-            ${{ runner.os }}
+            ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-jars
+            ${{ runner.os }}-python-
 
       - name: Build Worker Image
         uses: docker/build-push-action@v5

--- a/.github/workflows/oracle-tests.yml
+++ b/.github/workflows/oracle-tests.yml
@@ -24,11 +24,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ./cached_jars
-          key: ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-oracle-jars
+          key: ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-jars
           restore-keys: |
-            ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-oracle-jars
-            ${{ runner.os }}-python
-            ${{ runner.os }}
+            ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-jars
+            ${{ runner.os }}-python-
 
       - name: Build Worker Image
         uses: docker/build-push-action@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,10 +38,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-py-${{ hashFiles('**/poetry.lock') }}-${{ env.DEFAULT_PYTHON }}
+          key: ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-release-${{ hashFiles('**/poetry.lock') }}
           restore-keys: |
-            ${{ runner.os }}-py-${{ hashFiles('**/poetry.lock') }}-
-            ${{ runner.os }}-py-
+            ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-release-${{ hashFiles('**/poetry.lock') }}
+            ${{ runner.os }}-python-
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/s3-tests.yml
+++ b/.github/workflows/s3-tests.yml
@@ -24,11 +24,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ./cached_jars
-          key: ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-s3-jars
+          key: ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-jars
           restore-keys: |
-            ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-s3-jars
-            ${{ runner.os }}-python
-            ${{ runner.os }}
+            ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-jars
+            ${{ runner.os }}-python-
 
       - name: Build Worker Image
         uses: docker/build-push-action@v5

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -41,8 +41,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-tests-unit-${{ hashFiles('**/poetry.lock') }}
             ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-tests-unit-
-            ${{ runner.os }}-python
-            ${{ runner.os }}
+            ${{ runner.os }}-python-
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Github has a limit for CI cache - 10Gb per repo. Active images caching leads to cache size exceeding the limit, and thus cache items are evicted. Including caches from develop branch which are used as a seed for caches in other branches.

Here I've added CI workflow which deletes caches related to feature/bugfix branch, just after PR is merged/closed.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.