### PR TITLE
[DOP-15512] Download only packages required by tests

### DIFF
--- a/.github/workflows/hdfs-tests.yml
+++ b/.github/workflows/hdfs-tests.yml
@@ -24,9 +24,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ./cached_jars
-          key: ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-jars
+          key: ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-hdfs
           restore-keys: |
-            ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-jars
+            ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-hdfs
             ${{ runner.os }}-python-
 
       - name: Build Worker Image

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -24,9 +24,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ./cached_jars
-          key: ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-jars
+          key: ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-hive
           restore-keys: |
-            ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-jars
+            ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-hive
             ${{ runner.os }}-python-
 
       - name: Build Worker Image

--- a/.github/workflows/oracle-tests.yml
+++ b/.github/workflows/oracle-tests.yml
@@ -24,9 +24,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ./cached_jars
-          key: ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-jars
+          key: ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-oracle
           restore-keys: |
-            ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-jars
+            ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-oracle
             ${{ runner.os }}-python-
 
       - name: Build Worker Image

--- a/.github/workflows/s3-tests.yml
+++ b/.github/workflows/s3-tests.yml
@@ -24,9 +24,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ./cached_jars
-          key: ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-jars
+          key: ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-s3
           restore-keys: |
-            ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-jars
+            ${{ runner.os }}-python-${{ env.DEFAULT_PYTHON }}-test-s3
             ${{ runner.os }}-python-
 
       - name: Build Worker Image

--- a/docs/changelog/next_release/46.bugfix.rst
+++ b/docs/changelog/next_release/46.bugfix.rst
@@ -1,0 +1,1 @@
+Use Hadoop AWS ``magic`` commiter only if transfer *target* is S3.

--- a/syncmaster/worker/spark.py
+++ b/syncmaster/worker/spark.py
@@ -76,17 +76,20 @@ def get_spark_session_conf(
         maven_packages.extend(get_packages(db_type=db_type.type))  # type: ignore
         excluded_packages.extend(get_excluded_packages(db_type=db_type.type))  # type: ignore
 
-    log.debug("Passing Maven packages: %s", maven_packages)
-
     config = {
         "spark.jars.packages": ",".join(maven_packages),
         "spark.sql.pyspark.jvmStacktrace.enabled": "true",
     }
 
+    if maven_packages:
+        log.debug("Include Maven packages: %s", maven_packages)
+        config["spark.jars.packages"] = ",".join(maven_packages)
+
     if excluded_packages:
+        log.debug("Exclude Maven packages: %s", excluded_packages)
         config["spark.jars.excludes"] = ",".join(excluded_packages)
 
-    if source.type == "s3":  # type: ignore
+    if target.type == "s3":  # type: ignore
         config.update(
             {
                 "spark.hadoop.fs.s3a.committer.magic.enabled": "true",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

* Use only Spark packages required by selected tests, e.g. download Oracle package only if Oracle tests are running. This reduces both .jar cache size (500Mb -> 1.5Mb) and Spark session startup time.
* Use hadoop-aws `magic` commiter only if S3 is a *target*. Previously it was used only if S3 is a *source*, but this does not make any sense, commiter is used only for writing data.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.