### PR TITLE
[DOP-19835] Fix GET /v1/groups skipping some groups

### DIFF
--- a/syncmaster/backend/__init__.py
+++ b/syncmaster/backend/__init__.py
@@ -4,7 +4,6 @@ from fastapi import FastAPI, HTTPException
 from starlette.middleware.cors import CORSMiddleware
 
 from syncmaster.backend.api.deps import (
-    AuthMarker,
     DatabaseEngineMarker,
     DatabaseSessionMarker,
     SettingsMarker,
@@ -15,7 +14,6 @@ from syncmaster.backend.handler import (
     http_exception_handler,
     syncmsater_exception_handler,
 )
-from syncmaster.backend.services import get_auth_scheme
 from syncmaster.config import Settings
 from syncmaster.db.factory import create_engine, create_session_factory, get_uow
 from syncmaster.exceptions import SyncmasterError
@@ -41,15 +39,12 @@ def application_factory(settings: Settings) -> FastAPI:
     engine = create_engine(connection_uri=settings.build_db_connection_uri())
     session_factory = create_session_factory(engine=engine)
 
-    auth_scheme = get_auth_scheme(settings)
-
     application.dependency_overrides.update(
         {
             SettingsMarker: lambda: settings,
             DatabaseEngineMarker: lambda: engine,
             DatabaseSessionMarker: lambda: session_factory,
             UnitOfWorkMarker: get_uow(session_factory, settings),
-            AuthMarker: auth_scheme,
         },
     )
 

--- a/syncmaster/backend/api/deps.py
+++ b/syncmaster/backend/api/deps.py
@@ -1,9 +1,5 @@
 # SPDX-FileCopyrightText: 2023-2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
-class AuthMarker:
-    pass
-
-
 class SettingsMarker:
     pass
 

--- a/syncmaster/backend/services/__init__.py
+++ b/syncmaster/backend/services/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
-from syncmaster.backend.services.auth import get_auth_scheme, get_user
+from syncmaster.backend.services.auth import get_user
 from syncmaster.backend.services.unit_of_work import UnitOfWork

--- a/syncmaster/config.py
+++ b/syncmaster/config.py
@@ -23,7 +23,6 @@ class Settings(BaseSettings):
 
     SECRET_KEY: str = "secret"
     SECURITY_ALGORITHM: str = "HS256"
-    AUTH_TOKEN_URL: str = "v1/auth/token"
     CRYPTO_KEY: str = "UBgPTioFrtH2unlC4XFDiGf5sYfzbdSf_VgiUSaQc94="
 
     POSTGRES_HOST: str

--- a/syncmaster/db/repositories/group.py
+++ b/syncmaster/db/repositories/group.py
@@ -41,6 +41,7 @@ class GroupRepository(Repository[Group]):
     ):
         stmt = (
             select(Group)
+            .distinct()
             .join(
                 UserGroup,
                 UserGroup.group_id == Group.id,
@@ -53,7 +54,6 @@ class GroupRepository(Repository[Group]):
                     Group.owner_id == current_user_id,
                 ),
             )
-            .group_by(Group.id)
         )
 
         return await self._paginate_scalar_result(query=stmt.order_by(Group.name), page=page, page_size=page_size)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

When Group had a lot of bound UserGroup rows, the page limit in `GET /v1/groups` was applied to these rows instead of distinct Groups. Fixed.

Also fix missing "Authorize" button in Swagger.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.