### PR TITLE
[DOP-19780] Add /users/me endpoint

### DIFF
--- a/syncmaster/backend/api/v1/users.py
+++ b/syncmaster/backend/api/v1/users.py
@@ -35,10 +35,8 @@ async def get_users(
 @router.get("/users/me")
 async def read_current_user(
     current_user: User = Depends(get_user(is_active=True)),
-    unit_of_work: UnitOfWork = Depends(UnitOfWorkMarker),
 ) -> ReadUserSchema:
-    user = await unit_of_work.user.read_by_id(user_id=current_user.id, is_active=True)
-    return ReadUserSchema.from_orm(user)
+    return ReadUserSchema.from_orm(current_user)
 
 
 @router.get("/users/{user_id}", dependencies=[Depends(get_user(is_active=True))])

--- a/syncmaster/backend/api/v1/users.py
+++ b/syncmaster/backend/api/v1/users.py
@@ -32,6 +32,15 @@ async def get_users(
     return UserPageSchema.from_pagination(pagination)
 
 
+@router.get("/users/me")
+async def read_current_user(
+    current_user: User = Depends(get_user(is_active=True)),
+    unit_of_work: UnitOfWork = Depends(UnitOfWorkMarker),
+) -> ReadUserSchema:
+    user = await unit_of_work.user.read_by_id(user_id=current_user.id, is_active=True)
+    return ReadUserSchema.from_orm(user)
+
+
 @router.get("/users/{user_id}", dependencies=[Depends(get_user(is_active=True))])
 async def read_user(
     user_id: int,

--- a/tests/test_unit/test_users.py
+++ b/tests/test_unit/test_users.py
@@ -54,6 +54,45 @@ async def test_get_users(
     }
 
 
+async def test_get_current_user(
+    client: AsyncClient,
+    simple_user: MockUser,
+    inactive_user: MockUser,
+):
+    # without authentication
+    response = await client.get("/v1/users/me")
+    assert response.status_code == 401
+    assert response.json() == {
+        "ok": False,
+        "status_code": 401,
+        "message": "Not authenticated",
+    }
+
+    # active user
+    response = await client.get(
+        "/v1/users/me",
+        headers={"Authorization": f"Bearer {simple_user.token}"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "id": simple_user.id,
+        "is_superuser": simple_user.is_superuser,
+        "username": simple_user.username,
+    }
+
+    # inactive user
+    response = await client.get(
+        "/v1/users/me",
+        headers={"Authorization": f"Bearer {inactive_user.token}"},
+    )
+    assert response.status_code == 403
+    assert response.json() == {
+        "ok": False,
+        "status_code": 403,
+        "message": "Inactive user",
+    }
+
+
 async def test_get_user(
     client: AsyncClient,
     simple_user: MockUser,


### PR DESCRIPTION
## Change Summary

In the endpoint for managing group permissions, a user identifier was required. Previously, it could only be obtained by iterating through all users and comparing the login with the current one. Instead, a new endpoint GET /users/me has been added, which returns the details of the current user.

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.