### PR TITLE
[DOP-19935] - add <role> attribute to /v1/groups response

### DIFF
--- a/docs/changelog/next_release/97.breaking.rst
+++ b/docs/changelog/next_release/97.breaking.rst
@@ -1,0 +1,1 @@
+Change response format for `GET /v1/groups` - add **current user role** for each group

--- a/syncmaster/backend/api/v1/groups.py
+++ b/syncmaster/backend/api/v1/groups.py
@@ -26,6 +26,7 @@ router = APIRouter(tags=["Groups"], responses=get_error_responses())
 async def read_groups(
     page: int = Query(gt=0, default=1),
     page_size: int = Query(gt=0, le=200, default=20),
+    role: str | None = Query(default=None),
     current_user: User = Depends(get_user(is_active=True)),
     unit_of_work: UnitOfWork = Depends(UnitOfWorkMarker),
     search_query: str | None = Query(
@@ -45,6 +46,7 @@ async def read_groups(
             page=page,
             page_size=page_size,
             current_user_id=current_user.id,
+            role=role,
             search_query=search_query,
         )
     return GroupPageSchema.from_pagination(pagination=pagination)

--- a/syncmaster/db/models.py
+++ b/syncmaster/db/models.py
@@ -65,22 +65,16 @@ class GroupMemberRole(enum.StrEnum):
         role1: str | GroupMemberRole,
         role2: str | GroupMemberRole,
     ) -> bool:
-        try:
-            role1_enum = cls(role1) if isinstance(role1, str) else role1
-            role2_enum = cls(role2) if isinstance(role2, str) else role2
-            hierarchy = cls.role_hierarchy()
-            return hierarchy.get(role1_enum, 0) >= hierarchy.get(role2_enum, 0)
-        except ValueError:
-            raise ValueError(f"Invalid role(s): {role1}, {role2}")
+        role1_enum = cls(role1) if isinstance(role1, str) else role1
+        role2_enum = cls(role2) if isinstance(role2, str) else role2
+        hierarchy = cls.role_hierarchy()
+        return hierarchy.get(role1_enum, 0) >= hierarchy.get(role2_enum, 0)
 
     @classmethod
     def roles_at_least(cls, role: str | GroupMemberRole) -> list[str]:
-        try:
-            role_enum = cls(role) if isinstance(role, str) else role
-            required_level = cls.role_hierarchy()[role_enum]
-            return [r.value for r, level in cls.role_hierarchy().items() if level >= required_level]
-        except KeyError:
-            raise ValueError(f"Invalid role: {role}")
+        role_enum = cls(role) if isinstance(role, str) else role
+        required_level = cls.role_hierarchy()[role_enum]
+        return [r.value for r, level in cls.role_hierarchy().items() if level >= required_level]
 
 
 class User(Base, TimestampMixin, DeletableMixin):

--- a/syncmaster/db/models.py
+++ b/syncmaster/db/models.py
@@ -29,7 +29,21 @@ from syncmaster.db.mixins import DeletableMixin, ResourceMixin, TimestampMixin
 class GroupMemberRole(enum.StrEnum):
     Maintainer = "Maintainer"
     Developer = "Developer"
+    Owner = "Owner"
     Guest = "Guest"
+    _Superuser = "Superuser"
+
+    @classmethod
+    def public_roles(cls):
+        return [cls.Maintainer, cls.Developer, cls.Guest]
+
+    @classmethod
+    def public_roles_str(cls):
+        return ", ".join([role for role in cls.public_roles()])
+
+    @classmethod
+    def is_public_role(cls, role: str):
+        return role in cls.public_roles()
 
 
 class User(Base, TimestampMixin, DeletableMixin):
@@ -82,6 +96,7 @@ class UserGroup(Base):
         ChoiceType(GroupMemberRole),
         nullable=False,
     )
+    group: Mapped[Group] = relationship("Group")
 
 
 class Connection(Base, ResourceMixin, DeletableMixin, TimestampMixin):

--- a/syncmaster/db/models.py
+++ b/syncmaster/db/models.py
@@ -34,16 +34,53 @@ class GroupMemberRole(enum.StrEnum):
     _Superuser = "Superuser"
 
     @classmethod
-    def public_roles(cls):
+    def public_roles(cls) -> list[GroupMemberRole]:
         return [cls.Maintainer, cls.Developer, cls.Guest]
 
     @classmethod
-    def public_roles_str(cls):
-        return ", ".join([role for role in cls.public_roles()])
+    def public_roles_str(cls) -> str:
+        return ", ".join([role.value for role in cls.public_roles()])
 
     @classmethod
-    def is_public_role(cls, role: str):
-        return role in cls.public_roles()
+    def is_public_role(cls, role: str) -> bool:
+        try:
+            role_enum = cls(role)
+            return role_enum in cls.public_roles()
+        except ValueError:
+            return False
+
+    @classmethod
+    def role_hierarchy(cls) -> dict[GroupMemberRole, int]:
+        return {
+            cls.Guest: 1,
+            cls.Developer: 2,
+            cls.Maintainer: 3,
+            cls.Owner: 4,
+            cls._Superuser: 5,
+        }
+
+    @classmethod
+    def is_at_least_privilege_level(
+        cls,
+        role1: str | GroupMemberRole,
+        role2: str | GroupMemberRole,
+    ) -> bool:
+        try:
+            role1_enum = cls(role1) if isinstance(role1, str) else role1
+            role2_enum = cls(role2) if isinstance(role2, str) else role2
+            hierarchy = cls.role_hierarchy()
+            return hierarchy.get(role1_enum, 0) >= hierarchy.get(role2_enum, 0)
+        except ValueError:
+            raise ValueError(f"Invalid role(s): {role1}, {role2}")
+
+    @classmethod
+    def roles_at_least(cls, role: str | GroupMemberRole) -> list[str]:
+        try:
+            role_enum = cls(role) if isinstance(role, str) else role
+            required_level = cls.role_hierarchy()[role_enum]
+            return [r.value for r, level in cls.role_hierarchy().items() if level >= required_level]
+        except KeyError:
+            raise ValueError(f"Invalid role: {role}")
 
 
 class User(Base, TimestampMixin, DeletableMixin):

--- a/syncmaster/db/models.py
+++ b/syncmaster/db/models.py
@@ -31,7 +31,7 @@ class GroupMemberRole(enum.StrEnum):
     Developer = "Developer"
     Owner = "Owner"
     Guest = "Guest"
-    _Superuser = "Superuser"
+    Superuser = "Superuser"
 
     @classmethod
     def public_roles(cls) -> list[GroupMemberRole]:
@@ -56,7 +56,7 @@ class GroupMemberRole(enum.StrEnum):
             cls.Developer: 2,
             cls.Maintainer: 3,
             cls.Owner: 4,
-            cls._Superuser: 5,
+            cls.Superuser: 5,
         }
 
     @classmethod

--- a/syncmaster/db/repositories/group.py
+++ b/syncmaster/db/repositories/group.py
@@ -6,7 +6,7 @@ from typing import NoReturn
 from sqlalchemy import ScalarResult, func, insert, select, update
 from sqlalchemy.exc import DBAPIError, IntegrityError, NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import joinedload
 
 from syncmaster.db.models import Group, GroupMemberRole, User, UserGroup
 from syncmaster.db.repositories.base import Repository
@@ -35,69 +35,107 @@ class GroupRepository(Repository[Group]):
         stmt = select(Group).where(Group.is_deleted.is_(False))
         if search_query:
             stmt = self._construct_vector_search(stmt, search_query)
-        return await self._paginate_scalar_result(query=stmt.order_by(Group.name), page=page, page_size=page_size)
+
+        paginated_result = await self._paginate_scalar_result(
+            query=stmt.order_by(Group.name),
+            page=page,
+            page_size=page_size,
+        )
+        items = [{"data": group, "role": GroupMemberRole._Superuser} for group in paginated_result.items]
+
+        return Pagination(
+            items=items,
+            total=paginated_result.total,
+            page=page,
+            page_size=page_size,
+        )
 
     async def paginate_for_user(
         self,
         page: int,
         page_size: int,
         current_user_id: int,
-        search_query: str | None = None,
-    ):
-        # query for UserGroup relationships
-        stmt_user_groups = (
-            select(UserGroup)
-            .options(selectinload(UserGroup.group))
-            .where(
-                UserGroup.user_id == current_user_id,
-                UserGroup.group.has(Group.is_deleted.is_(False)),
-            )
-            .limit(page_size)
-            .offset((page - 1) * page_size)
-        )
+        role: str | None = None,
+    ) -> Pagination:
+        roles_at_least = GroupMemberRole.roles_at_least(role) if role else None
 
-        # Query for groups owned by the user (excluding deleted groups)
-        stmt_owned_groups = (
+        # query for groups where the user is the owner
+        owned_groups_stmt = (
             select(Group)
             .where(
                 Group.owner_id == current_user_id,
                 Group.is_deleted.is_(False),
             )
-            .limit(page_size)
-            .offset((page - 1) * page_size)
+            .order_by(Group.name)
         )
 
-        result_user_groups = await self._session.execute(stmt_user_groups)
-        user_groups = result_user_groups.scalars().all()
+        # if a role is specified and 'Owner' does not meet the required level, exclude owned groups
+        if role and not GroupMemberRole.is_at_least_privilege_level(
+            GroupMemberRole.Owner,
+            role,
+        ):
+            owned_groups = []
+            total_owned_groups = 0
+        else:
+            # get total count of owned groups
+            total_owned_groups = (
+                await self._session.scalar(
+                    select(func.count()).select_from(owned_groups_stmt.subquery()),
+                )
+                or 0
+            )
 
-        result_owned_groups = await self._session.execute(stmt_owned_groups)
-        owned_groups = result_owned_groups.scalars().all()
+            # fetch owned groups
+            owned_groups_result = await self._session.execute(
+                owned_groups_stmt,
+            )
+            owned_groups = [
+                {"data": group, "role": GroupMemberRole.Owner.value} for group in owned_groups_result.scalars().all()
+            ]
 
-        items = [{"data": user_group.group, "role": user_group.role} for user_group in user_groups]
-        items.extend({"data": group, "role": GroupMemberRole.Owner} for group in owned_groups)
-
-        total_count = await self._session.scalar(
-            select(func.count())
-            .select_from(UserGroup)
+        #  query for groups where the user is a member (not Owner)
+        user_groups_stmt = (
+            select(UserGroup)
+            .join(Group, UserGroup.group_id == Group.id)
             .where(
                 UserGroup.user_id == current_user_id,
-                UserGroup.group.has(Group.is_deleted.is_(False)),
-            ),
-        )
-
-        total_owned_groups_count = await self._session.scalar(
-            select(func.count())
-            .select_from(Group)
-            .where(
-                Group.owner_id == current_user_id,
                 Group.is_deleted.is_(False),
-            ),
+            )
+            .order_by(Group.name)
         )
 
-        total_count += total_owned_groups_count
+        # apply role-based filtering if a role is specified
+        if roles_at_least:
+            user_groups_stmt = user_groups_stmt.where(
+                UserGroup.role.in_(roles_at_least),
+            )
+
+        # get total count of user groups
+        total_user_groups = (
+            await self._session.scalar(
+                select(func.count()).select_from(user_groups_stmt.subquery()),
+            )
+            or 0
+        )
+
+        user_groups_result = await self._session.execute(
+            user_groups_stmt.options(joinedload(UserGroup.group)),
+        )
+        user_groups = [
+            {"data": user_group.group, "role": user_group.role.value}
+            for user_group in user_groups_result.scalars().all()
+        ]
+
+        # combine owned groups and user groups
+        combined_groups = owned_groups + user_groups
+        total_count = total_owned_groups + total_user_groups
+
+        start = (page - 1) * page_size
+        end = start + page_size
+        paginated_items = combined_groups[start:end]
 
         return Pagination(
-            items=items,
+            items=paginated_items,
             total=total_count,
             page=page,
             page_size=page_size,

--- a/syncmaster/schemas/v1/groups.py
+++ b/syncmaster/schemas/v1/groups.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2023-2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from syncmaster.db.models import GroupMemberRole
 from syncmaster.schemas.v1.page import PageSchema
@@ -21,6 +21,20 @@ class CreateGroupSchema(BaseModel):
 class AddUserSchema(BaseModel):
     role: GroupMemberRole
 
+    @model_validator(mode="before")
+    def validate_role(cls, values):
+        if isinstance(values, dict):
+            role = values.get("role")
+        else:
+            # access 'role' directly if 'values' is an object
+            role = getattr(values, "role", None)
+
+        if role and not GroupMemberRole.is_public_role(role):
+            raise ValueError(
+                f"Input should be one of: {GroupMemberRole.public_roles_str()}",
+            )
+        return values
+
     class Config:
         from_attributes = True
 
@@ -35,5 +49,13 @@ class ReadGroupSchema(BaseModel):
         from_attributes = True
 
 
+class GroupWithUserRoleSchema(BaseModel):
+    data: ReadGroupSchema
+    role: GroupMemberRole
+
+    class Config:
+        from_attributes = True
+
+
 class GroupPageSchema(PageSchema):
-    items: list[ReadGroupSchema]
+    items: list[GroupWithUserRoleSchema]

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -12,6 +12,7 @@ class UserTestRoles(enum.StrEnum):
     Maintainer = "Maintainer"
     Developer = "Developer"
     Guest = "Guest"
+    _Superuser = "Superuser"
 
 
 class MockUser:

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -16,7 +16,7 @@ class UserTestRoles(enum.StrEnum):
 
 
 class MockUser:
-    def __init__(self, user: User, auth_token: str, role: str) -> None:
+    def __init__(self, user: User, auth_token: str, role: str | None = None) -> None:
         self.user = user
         self.token = auth_token
         self.role = role

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -12,7 +12,7 @@ class UserTestRoles(enum.StrEnum):
     Maintainer = "Maintainer"
     Developer = "Developer"
     Guest = "Guest"
-    _Superuser = "Superuser"
+    Superuser = "Superuser"
 
 
 class MockUser:

--- a/tests/test_unit/conftest.py
+++ b/tests/test_unit/conftest.py
@@ -86,7 +86,7 @@ async def superuser(session: AsyncSession, settings: Settings):
         yield MockUser(
             user=user,
             auth_token=sign_jwt(user.id, settings),
-            role=UserTestRoles.Developer,
+            role=UserTestRoles.Superuser,
         )
 
 

--- a/tests/test_unit/conftest.py
+++ b/tests/test_unit/conftest.py
@@ -158,6 +158,7 @@ async def group(session: AsyncSession, settings: Settings) -> MockGroup:
         is_active=True,
     )
     group = await create_group(session=session, name="notempty_group", owner_id=owner.id)
+
     members: list[MockUser] = []
     for username in (
         "not_empty_group_member_maintainer",

--- a/tests/test_unit/test_groups/test_add_user_to_group.py
+++ b/tests/test_unit/test_groups/test_add_user_to_group.py
@@ -132,11 +132,11 @@ async def test_owner_cannot_add_user_to_group_with_wrong_role(
             "message": "Invalid request",
             "details": [
                 {
-                    "context": {"expected": "'Maintainer', 'Developer' or 'Guest'"},
-                    "input": "WrongRole",
-                    "location": ["body", "role"],
-                    "message": "Input should be 'Maintainer', 'Developer' or 'Guest'",
-                    "code": "enum",
+                    "location": ["body"],
+                    "message": "Value error, Input should be one of: Maintainer, Developer, Guest",
+                    "code": "value_error",
+                    "context": {},
+                    "input": {"role": "WrongRole"},
                 },
             ],
         },

--- a/tests/test_unit/test_groups/test_read_groups.py
+++ b/tests/test_unit/test_groups/test_read_groups.py
@@ -35,45 +35,13 @@ async def test_group_member_can_read_groups(
         },
         "items": [
             {
-                "id": group.id,
-                "name": group.name,
-                "description": group.description,
-                "owner_id": group.owner_id,
-            },
-        ],
-    }
-    assert result.status_code == 200
-
-
-async def test_group_owner_can_read_empty_group(
-    client: AsyncClient,
-    empty_group: MockGroup,
-):
-    # Arrange
-    owner = empty_group.get_member_of_role(UserTestRoles.Owner)
-    # Act
-    result = await client.get(
-        "v1/groups",
-        headers={"Authorization": f"Bearer {owner.token}"},
-    )
-    # Assert
-    assert result.json() == {
-        "meta": {
-            "page": 1,
-            "pages": 1,
-            "total": 1,
-            "page_size": 20,
-            "has_next": False,
-            "has_previous": False,
-            "next_page": None,
-            "previous_page": None,
-        },
-        "items": [
-            {
-                "id": empty_group.id,
-                "name": empty_group.name,
-                "description": empty_group.description,
-                "owner_id": empty_group.owner_id,
+                "data": {
+                    "id": group.id,
+                    "name": group.name,
+                    "description": group.description,
+                    "owner_id": group.owner_id,
+                },
+                "role": role_guest_plus,
             },
         ],
     }
@@ -132,16 +100,22 @@ async def test_superuser_can_read_all_groups(
         },
         "items": [
             {
-                "id": empty_group.id,
-                "name": empty_group.name,
-                "description": empty_group.description,
-                "owner_id": empty_group.owner_id,
+                "data": {
+                    "id": empty_group.id,
+                    "name": empty_group.name,
+                    "description": empty_group.description,
+                    "owner_id": empty_group.owner_id,
+                },
+                "role": UserTestRoles._Superuser,
             },
             {
-                "id": group.id,
-                "name": group.name,
-                "description": group.description,
-                "owner_id": group.owner_id,
+                "data": {
+                    "id": group.id,
+                    "name": group.name,
+                    "description": group.description,
+                    "owner_id": group.owner_id,
+                },
+                "role": UserTestRoles._Superuser,
             },
         ],
     }

--- a/tests/test_unit/test_groups/test_read_groups.py
+++ b/tests/test_unit/test_groups/test_read_groups.py
@@ -138,7 +138,6 @@ async def test_unauthorized_user_cannot_read_groups(
     assert result.status_code == 401
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "role,expected_total,expected_roles",
     [
@@ -169,6 +168,39 @@ async def test_filter_groups_by_role(
     assert len(response_json["items"]) == expected_total
 
     assert {item.get("role") for item in response_json["items"]} == expected_roles
+
+
+@pytest.mark.parametrize(
+    "role,expected_total",
+    [
+        (None, 4),  # No role filter
+        ("Guest", 4),
+        ("Developer", 4),
+        ("Maintainer", 4),
+        ("Owner", 4),
+    ],
+)
+async def test_filter_groups_not_applied_to_superuser(
+    client: AsyncClient,
+    user_with_many_roles: MockUser,  # keep it, needed to create different groups
+    superuser: MockUser,
+    role: str,
+    expected_total: int,
+):
+    role_query = f"?role={role}" if role else ""
+    response = await client.get(
+        f"v1/groups{role_query}",
+        headers={"Authorization": f"Bearer {superuser.token}"},
+    )
+
+    assert response.status_code == 200
+    response_json = response.json()
+
+    assert response_json["meta"]["total"] == expected_total
+    assert len(response_json["items"]) == expected_total
+
+    for item in response_json["items"]:
+        assert item.get("role") == "Superuser"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unit/test_groups/test_update_member_role.py
+++ b/tests/test_unit/test_groups/test_update_member_role.py
@@ -69,22 +69,22 @@ async def test_owner_of_group_can_not_update_user_role_with_wrong_role(
     )
 
     # Assert
-    assert result.status_code == 422
     assert result.json() == {
         "error": {
             "code": "invalid_request",
             "message": "Invalid request",
             "details": [
                 {
-                    "context": {"expected": "'Maintainer', 'Developer' or 'Guest'"},
-                    "input": "Unknown",
-                    "location": ["body", "role"],
-                    "message": "Input should be 'Maintainer', 'Developer' or 'Guest'",
-                    "code": "enum",
+                    "location": ["body"],
+                    "message": "Value error, Input should be one of: Maintainer, Developer, Guest",
+                    "code": "value_error",
+                    "context": {},
+                    "input": {"role": "Unknown"},
                 },
             ],
         },
     }
+    assert result.status_code == 422
 
 
 async def test_maintainer_below_can_not_update_user_role(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

- change response format for endpoint `GET /v1/groups` from:

```
  {
    "meta": {
        "page": 1,
        "pages": 1,
        "total": 2,
        "page_size": 20,
        "has_next": False,
        "has_previous": False,
        "next_page": None,
        "previous_page": None,
    },
    "items": [
             {
                "id": 18698,
                "name": "group_for_Maintainer",
                "description": "",
                "owner_id": 73055,
            },
            {
                "id": 18699,
                "name": "group_for_Developer",
                "description": "",
                "owner_id": 73055,
            },
            ]
}

```

to: 

```

{
                "meta": {
                    "page": 1,
                    "pages": 1,
                    "total": 2,
                    "page_size": 20,
                    "has_next": False,
                    "has_previous": False,
                    "next_page": None,
                    "previous_page": None,
                },
                "items": [
                    {
                        "data": {
                            "id": 18698,
                            "name": "group_for_Maintainer",
                            "description": "",
                            "owner_id": 73055,
                        },
                        "role": "Maintainer",
                    },
                    {
                        "data": {
                            "id": 18700,
                            "name": "group_for_Guest",
                            "description": "",
                            "owner_id": 73055,
                        },
                        "role": "Guest",
                    },
                ],
            },
```

adding to each response currents user role in related group

- add filtering param `role` to endpoint `GET /v1/groups?role=`, now it is possible to filter items in previous response that at least have passed role to the query parameter
- add following tests

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.