### PR TITLE
[DOP-20893] Add <role> attribute to /v1/groups/:id response

### DIFF
--- a/docs/changelog/next_release/109.breaking.rst
+++ b/docs/changelog/next_release/109.breaking.rst
@@ -1,0 +1,1 @@
+Change response format for `GET /v1/groups/:id` - add **current user role** for group

--- a/tests/test_unit/test_groups/test_read_group_by_id.py
+++ b/tests/test_unit/test_groups/test_read_group_by_id.py
@@ -20,10 +20,13 @@ async def test_member_of_group_can_read_by_id(
     )
     # Assert
     assert result.json() == {
-        "id": group.id,
-        "name": group.name,
-        "description": group.description,
-        "owner_id": group.owner_id,
+        "data": {
+            "id": group.id,
+            "name": group.name,
+            "description": group.description,
+            "owner_id": group.owner_id,
+        },
+        "role": user.role.value,
     }
     assert result.status_code == 200
 
@@ -86,10 +89,13 @@ async def test_superuser_can_read_group(
     )
     # Assert
     assert result.json() == {
-        "id": group.id,
-        "name": group.name,
-        "description": group.description,
-        "owner_id": group.owner_id,
+        "data": {
+            "id": group.id,
+            "name": group.name,
+            "description": group.description,
+            "owner_id": group.owner_id,
+        },
+        "role": superuser.role.value,
     }
     assert result.status_code == 200
 

--- a/tests/test_unit/test_groups/test_update_group_by_id.py
+++ b/tests/test_unit/test_groups/test_update_group_by_id.py
@@ -28,7 +28,10 @@ async def test_owner_of_group_can_update_group(client: AsyncClient, empty_group:
         f"v1/groups/{empty_group.id}",
         headers={"Authorization": f"Bearer {empty_group.get_member_of_role(UserTestRoles.Owner).token}"},
     )
-    assert check_result.json() == group_data
+    assert check_result.json() == {
+        "data": group_data,
+        "role": UserTestRoles.Owner,
+    }
     assert check_result.status_code == 200
 
 
@@ -109,7 +112,10 @@ async def test_superuser_can_update_group(client: AsyncClient, empty_group: Mock
         headers={"Authorization": f"Bearer {superuser.token}"},
     )
     assert result.status_code == 200
-    assert result.json() == group_data
+    assert result.json() == {
+        "data": group_data,
+        "role": UserTestRoles.Superuser,
+    }
 
 
 async def test_validation_on_update_group(


### PR DESCRIPTION
## Change Summary
GET /v1/groups/:id endpoint changed the response format from:
```
{
  “id": 123,
  “name": "abc",
  “description": “cde”
}
```
to
```
{
  “data": {
    “id": 123,
    “name": "abc",
    “description": “cde”
  }, 
  “role”: “DEVELOPER”
}
```

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.