### PR TITLE
[DOP-19796] - add log_url before sending run task to celery worker

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -4,9 +4,13 @@ ENV=LOCAL
 # Debug
 SYNCMASTER__SERVER__DEBUG=true
 
-# Logging
+# Logging Backend
 SYNCMASTER__SERVER__LOGGING__SETUP=True
 SYNCMASTER__SERVER__LOGGING__PRESET=colored
+
+# Logging Worker
+SYNCMASTER__WORKER__LOGGING__SETUP=True
+SYNCMASTER__WORKER__LOGGING__PRESET=json
 
 # Postgres
 SYNCMASTER__DATABASE__URL=postgresql+asyncpg://syncmaster:changeme@db:5432/syncmaster

--- a/.env.local
+++ b/.env.local
@@ -8,6 +8,10 @@ export SYNCMASTER__SERVER__DEBUG=true
 export SYNCMASTER__SERVER__LOGGING__SETUP=True
 export SYNCMASTER__SERVER__LOGGING__PRESET=colored
 
+# Logging Worker
+export SYNCMASTER__WORKER__LOGGING__SETUP=True
+export SYNCMASTER__WORKER__LOGGING__PRESET=json
+
 # Postgres
 export SYNCMASTER__DATABASE__URL=postgresql+asyncpg://syncmaster:changeme@localhost:5432/syncmaster
 

--- a/docs/backend/configuration/logging.rst
+++ b/docs/backend/configuration/logging.rst
@@ -1,7 +1,7 @@
-.. _backend-configuration-logging:
+.. _configuration-logging:
 
 Logging settings
 ================
 
 
-.. autopydantic_model:: syncmaster.settings.server.log.LoggingSettings
+.. autopydantic_model:: syncmaster.settings.log.LoggingSettings

--- a/poetry.lock
+++ b/poetry.lock
@@ -3286,9 +3286,9 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 
 [extras]
 backend = ["alembic", "asgi-correlation-id", "asyncpg", "celery", "coloredlogs", "fastapi", "jinja2", "psycopg", "pydantic-settings", "python-jose", "python-json-logger", "python-multipart", "sqlalchemy", "sqlalchemy-utils", "uuid6", "uvicorn"]
-worker = ["asgi-correlation-id", "celery", "jinja2", "onetl", "psycopg", "pydantic-settings", "sqlalchemy", "sqlalchemy-utils", "uuid6"]
+worker = ["asgi-correlation-id", "celery", "coloredlogs", "jinja2", "onetl", "psycopg", "pydantic-settings", "python-json-logger", "sqlalchemy", "sqlalchemy-utils", "uuid6"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "2db69ba935a3cc8094ce9a4203236f4902c5cea5d4d4d0a1ceab3c453617b712"
+content-hash = "86edb5832161c81ddf76aa541e37bb901adf668e0b75b1cefab0952ed0604922"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,8 +98,9 @@ worker = [
     "jinja2",
     "psycopg",
     "uuid6",
+    "coloredlogs",
+    "python-json-logger",
 ]
-
 [tool.poetry.group.test.dependencies]
 pandas-stubs = "^2.2.2.240909"
 pytest = "^8.3.3"

--- a/syncmaster/settings/__init__.py
+++ b/syncmaster/settings/__init__.py
@@ -9,6 +9,7 @@ from pydantic_settings import BaseSettings
 from syncmaster.settings.broker import RabbitMQSettings
 from syncmaster.settings.database import DatabaseSettings
 from syncmaster.settings.server import ServerSettings
+from syncmaster.settings.worker import WorkerSettings
 
 
 class EnvTypes(StrEnum):
@@ -48,8 +49,6 @@ class Settings(BaseSettings):
     SECURITY_ALGORITHM: str = "HS256"
     CRYPTO_KEY: str = "UBgPTioFrtH2unlC4XFDiGf5sYfzbdSf_VgiUSaQc94="
 
-    CORRELATION_CELERY_HEADER_ID: str = "CORRELATION_CELERY_HEADER_ID"
-
     TOKEN_EXPIRED_TIME: int = 60 * 60 * 10  # 10 hours
     CREATE_SPARK_SESSION_FUNCTION: ImportString = "syncmaster.worker.spark.get_worker_spark_session"
 
@@ -57,7 +56,11 @@ class Settings(BaseSettings):
     broker: RabbitMQSettings = Field(description=":ref:`Broker settings <backend-configuration-broker>`")
     server: ServerSettings = Field(
         default_factory=ServerSettings,
-        description=":ref:`Server settings <backend-configuration>`",
+        description="Server settings <backend-configuration",
+    )
+    worker: WorkerSettings = Field(
+        default_factory=WorkerSettings,
+        description="Celery worker settings",
     )
 
     class Config:

--- a/syncmaster/settings/log/__init__.py
+++ b/syncmaster/settings/log/__init__.py
@@ -20,15 +20,25 @@ class LoggingSettings(BaseModel):
 
     .. code-block:: bash
 
+        # backend logging
         SYNCMASTER__SERVER__LOGGING__SETUP=True
         SYNCMASTER__SERVER__LOGGING__PRESET=json
+
+        # celery logging
+        SYNCMASTER__WORKER__LOGGING__SETUP=True
+        SYNCMASTER__WORKER__LOGGING__PRESET=json
 
     Passing custom logging config file:
 
     .. code-block:: bash
 
+        # backend logging
         SYNCMASTER__SERVER__LOGGING__SETUP=True
         SYNCMASTER__SERVER__LOGGING__CUSTOM__CONFIG_PATH=/some/logging.yml
+
+        # celery logging
+        SYNCMASTER__WORKER__LOGGING__SETUP=True
+        SYNCMASTER__WORKER__LOGGING__CUSTOM__CONFIG_PATH=/some/logging.yml
 
     Setup logging in some other way, e.g. using `uvicorn args <https://www.uvicorn.org/settings/#logging>`_:
 

--- a/syncmaster/settings/log/colored.yml
+++ b/syncmaster/settings/log/colored.yml
@@ -1,3 +1,4 @@
+# development usage only
 version: 1
 disable_existing_loggers: false
 
@@ -11,16 +12,21 @@ filters:
     default_value: '-'
 
 formatters:
-  json:
-    (): pythonjsonlogger.jsonlogger.JsonFormatter
+  colored:
+    (): coloredlogs.ColoredFormatter
     # Add correlation_id to log records
-    fmt: '%(processName)s %(process)d %(threadName)s %(thread)d %(name)s %(lineno)d %(levelname)s %(message)s %(correlation_id)s'
-    timestamp: true
+    fmt: '%(asctime)s.%(msecs)03d %(processName)s:%(process)d %(name)s:%(lineno)d [%(levelname)s] %(correlation_id)s %(message)s'
+    datefmt: '%Y-%m-%d %H:%M:%S'
 
 handlers:
   main:
     class: logging.StreamHandler
-    formatter: json
+    formatter: colored
+    filters: [correlation_id]
+    stream: ext://sys.stdout
+  celery:
+    class: logging.StreamHandler
+    formatter: colored
     filters: [correlation_id]
     stream: ext://sys.stdout
 
@@ -32,4 +38,8 @@ loggers:
   uvicorn:
     handlers: [main]
     level: INFO
+    propagate: false
+  celery:
+    level: DEBUG
+    handlers: [celery]
     propagate: false

--- a/syncmaster/settings/log/json.yml
+++ b/syncmaster/settings/log/json.yml
@@ -1,4 +1,3 @@
-# development usage only
 version: 1
 disable_existing_loggers: false
 
@@ -12,16 +11,21 @@ filters:
     default_value: '-'
 
 formatters:
-  plain:
-    (): logging.Formatter
+  json:
+    (): pythonjsonlogger.jsonlogger.JsonFormatter
     # Add correlation_id to log records
-    fmt: '%(asctime)s.%(msecs)03d %(processName)s:%(process)d %(name)s:%(lineno)d [%(levelname)s] %(correlation_id)s %(message)s'
-    datefmt: '%Y-%m-%d %H:%M:%S'
+    fmt: '%(processName)s %(process)d %(threadName)s %(thread)d %(name)s %(lineno)d %(levelname)s %(message)s %(correlation_id)s'
+    timestamp: true
 
 handlers:
   main:
     class: logging.StreamHandler
-    formatter: plain
+    formatter: json
+    filters: [correlation_id]
+    stream: ext://sys.stdout
+  celery:
+    class: logging.StreamHandler
+    formatter: json
     filters: [correlation_id]
     stream: ext://sys.stdout
 
@@ -33,4 +37,8 @@ loggers:
   uvicorn:
     handlers: [main]
     level: INFO
+    propagate: false
+  celery:
+    level: DEBUG
+    handlers: [celery]
     propagate: false

--- a/syncmaster/settings/log/plain.yml
+++ b/syncmaster/settings/log/plain.yml
@@ -12,8 +12,8 @@ filters:
     default_value: '-'
 
 formatters:
-  colored:
-    (): coloredlogs.ColoredFormatter
+  plain:
+    (): logging.Formatter
     # Add correlation_id to log records
     fmt: '%(asctime)s.%(msecs)03d %(processName)s:%(process)d %(name)s:%(lineno)d [%(levelname)s] %(correlation_id)s %(message)s'
     datefmt: '%Y-%m-%d %H:%M:%S'
@@ -21,7 +21,12 @@ formatters:
 handlers:
   main:
     class: logging.StreamHandler
-    formatter: colored
+    formatter: plain
+    filters: [correlation_id]
+    stream: ext://sys.stdout
+  celery:
+    class: logging.StreamHandler
+    formatter: plain
     filters: [correlation_id]
     stream: ext://sys.stdout
 
@@ -34,3 +39,7 @@ loggers:
     handlers: [main]
     level: INFO
     propagate: false
+    celery:
+      level: DEBUG
+      handlers: [celery]
+      propagate: false

--- a/syncmaster/settings/server/__init__.py
+++ b/syncmaster/settings/server/__init__.py
@@ -5,8 +5,8 @@ import textwrap
 
 from pydantic import BaseModel, Field
 
+from syncmaster.settings.log import LoggingSettings
 from syncmaster.settings.server.cors import CORSSettings
-from syncmaster.settings.server.log import LoggingSettings
 from syncmaster.settings.server.request_id import RequestIDSettings
 
 

--- a/syncmaster/settings/worker/__init__.py
+++ b/syncmaster/settings/worker/__init__.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2023-2024 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+from pydantic import BaseModel, Field
+
+from syncmaster.settings.log import LoggingSettings
+
+
+class WorkerSettings(BaseModel):
+    """Celery worker settings.
+
+    Examples
+    --------
+
+    .. code-block:: bash
+
+        SYNCMASTER__WORKER__LOGGING__PRESET=colored
+    """
+
+    logging: LoggingSettings = Field(
+        default_factory=LoggingSettings,
+        description=":ref:`Logging settings <configuration-logging>`",
+    )
+    CORRELATION_CELERY_HEADER_ID: str = "CORRELATION_CELERY_HEADER_ID"
+    LOG_URL_TEMPLATE: str = ""


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

- Add logic for updating `log_url` in `Run` table rendered from template for future viewing of celery worker logs
- Add `WorkerSettings` to configure work of celery worker (logging, log_url_template, etc.)

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.