### PR TITLE
[DOP-19794] Do not block event loop when using Celery

### DIFF
--- a/syncmaster/backend/api/v1/runs.py
+++ b/syncmaster/backend/api/v1/runs.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2023-2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
+import asyncio
 from datetime import datetime
 from typing import Annotated
 
@@ -129,7 +130,8 @@ async def start_run(
         )
 
     try:
-        celery.send_task(
+        await asyncio.to_thread(
+            celery.send_task,
             "run_transfer_task",
             kwargs={"run_id": run.id},
             queue=transfer.queue.name,

--- a/tests/test_unit/test_scheduler/test_transfer_job_manager.py
+++ b/tests/test_unit/test_scheduler/test_transfer_job_manager.py
@@ -80,7 +80,7 @@ async def test_send_job_to_celery_with_success(
     group_transfer: MockTransfer,
 ):
     # Arrange
-    mock_send_task = mocker.patch("syncmaster.worker.config.celery.send_task", new=AsyncMock())
+    mock_send_task = mocker.patch("syncmaster.worker.config.celery.send_task")
     mock_to_thread = mocker.patch("asyncio.to_thread", new_callable=AsyncMock)
 
     # Act
@@ -107,7 +107,7 @@ async def test_send_job_to_celery_with_failure(
     group_transfer: MockTransfer,
 ):
     # Arrange
-    mocker.patch("syncmaster.worker.config.celery.send_task", new=AsyncMock())
+    mocker.patch("syncmaster.worker.config.celery.send_task")
     mocker.patch("asyncio.to_thread", new_callable=AsyncMock, side_effect=KombuError)
 
     # Act & Assert


### PR DESCRIPTION
## Change Summary
The call to the synchronous celery.send_task() method in the asynchronous endpoint is wrapped in asyncio.to_thread to avoid event loop blocking, in particular when RabbitMQ is unavailable.

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.