### PR TITLE
[DOP-19793] Make queue name unique within a group

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -91,7 +91,7 @@ services:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
-    profiles: [worker, scheduler, s3, oracle, hdfs, hive, all]
+    profiles: [worker, s3, oracle, hdfs, hive, all]
 
   test-postgres:
     image: postgres

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -91,7 +91,7 @@ services:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
-    profiles: [worker, s3, oracle, hdfs, hive, all]
+    profiles: [worker, scheduler, s3, oracle, hdfs, hive, all]
 
   test-postgres:
     image: postgres

--- a/docs/changelog/next_release/119.bugfix.rst
+++ b/docs/changelog/next_release/119.bugfix.rst
@@ -1,0 +1,1 @@
+Now `Queue.name` is made unique within `group_id`

--- a/syncmaster/db/migrations/versions/2023-11-23_0003_create_queue_table.py
+++ b/syncmaster/db/migrations/versions/2023-11-23_0003_create_queue_table.py
@@ -21,8 +21,9 @@ depends_on = None
 def upgrade():
     op.create_table(
         "queue",
-        sa.Column("name", sa.String(length=128), nullable=False),
         sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("slug", sa.String(length=256), nullable=False),
         sa.Column("group_id", sa.BigInteger(), nullable=False),
         sa.Column("description", sa.String(length=512), nullable=False),
         sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
@@ -41,7 +42,7 @@ def upgrade():
             ondelete="CASCADE",
         ),
         sa.PrimaryKeyConstraint("id", name=op.f("pk__queue")),
-        sa.UniqueConstraint("name", name=op.f("uq__queue__name")),
+        sa.UniqueConstraint("slug", name=op.f("uq__queue__slug")),
     )
     op.create_index(op.f("ix__queue__group_id"), "queue", ["group_id"], unique=False)
 

--- a/syncmaster/db/models/group.py
+++ b/syncmaster/db/models/group.py
@@ -77,7 +77,7 @@ class Group(Base, TimestampMixin, DeletableMixin):
 
     owner: Mapped[User] = relationship(User)
     members: Mapped[list[User]] = relationship(User, secondary="user_group")
-    queue: Mapped[Queue] = relationship(back_populates="group")
+    queue: Mapped[Queue] = relationship(back_populates="group", cascade="all, delete-orphan")
 
     search_vector: Mapped[str] = mapped_column(
         TSVECTOR,

--- a/syncmaster/db/models/queue.py
+++ b/syncmaster/db/models/queue.py
@@ -17,7 +17,8 @@ if TYPE_CHECKING:
 
 
 class Queue(Base, ResourceMixin, TimestampMixin, DeletableMixin):
-    name: Mapped[str] = mapped_column(String(128), nullable=False, unique=True)
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    slug: Mapped[str] = mapped_column(String(256), nullable=False, unique=True)
 
     transfers: Mapped[list[Transfer]] = relationship(back_populates="queue")
     group: Mapped[Group] = relationship(back_populates="queue")
@@ -31,4 +32,4 @@ class Queue(Base, ResourceMixin, TimestampMixin, DeletableMixin):
     )
 
     def __repr__(self):
-        return f"<Queue name={self.name} description={self.description}>"
+        return f"<Queue name={self.name} slug={self.slug} description={self.description}>"

--- a/syncmaster/db/repositories/queue.py
+++ b/syncmaster/db/repositories/queue.py
@@ -197,7 +197,7 @@ class QueueRepository(RepositoryWithOwner[Queue]):
     @staticmethod
     def _raise_error(err: DBAPIError) -> NoReturn:
         constraint = err.__cause__.__cause__.constraint_name
-        if constraint == "uq__queue__name":
+        if constraint == "uq__queue__slug":
             raise DuplicatedQueueNameError
 
         raise SyncmasterError from err

--- a/syncmaster/schemas/v1/queue.py
+++ b/syncmaster/schemas/v1/queue.py
@@ -17,6 +17,8 @@ class CreateQueueSchema(BaseModel):
 
     @model_validator(mode="before")
     def generate_slug(cls, values):
+        if "group_id" not in values or "name" not in values:
+            raise ValueError("Fields name and group_id are required")
         values["slug"] = f"{values["group_id"]}-{values["name"]}"
         return values
 

--- a/syncmaster/schemas/v1/queue.py
+++ b/syncmaster/schemas/v1/queue.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2023-2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
-from pydantic import BaseModel, Field, constr, model_validator
-from pydantic.json_schema import SkipJsonSchema
+from pydantic import BaseModel, Field, computed_field, constr
 
 from syncmaster.schemas.v1.page import PageSchema
 
@@ -13,14 +12,11 @@ class CreateQueueSchema(BaseModel):
     )
     group_id: int = Field(..., description="Queue owner group id")
     description: str = Field(default="", description="Additional description")
-    slug: SkipJsonSchema[str] = Field(description="Generated slug for unique queue identification")
 
-    @model_validator(mode="before")
-    def generate_slug(cls, values):
-        if "group_id" not in values or "name" not in values:
-            raise ValueError("Fields name and group_id are required")
-        values["slug"] = f"{values["group_id"]}-{values["name"]}"
-        return values
+    @computed_field
+    @property
+    def slug(self) -> str:
+        return f"{self.group_id}-{self.name}"
 
 
 class ReadQueueSchema(BaseModel):

--- a/tests/test_unit/conftest.py
+++ b/tests/test_unit/conftest.py
@@ -1,4 +1,5 @@
 import secrets
+from collections.abc import AsyncGenerator
 
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -289,7 +290,7 @@ async def group_queue(
     session: AsyncSession,
     settings: Settings,
     mock_group: MockGroup,
-) -> Queue:
+) -> AsyncGenerator[Queue, None]:
     queue = await create_queue(
         session=session,
         name=f"{secrets.token_hex(5)}_test_queue",

--- a/tests/test_unit/conftest.py
+++ b/tests/test_unit/conftest.py
@@ -170,7 +170,7 @@ async def user_with_many_roles(session: AsyncSession, settings: Settings, simple
 
 
 @pytest_asyncio.fixture
-async def empty_group(session: AsyncSession, settings) -> MockGroup:
+async def empty_group(session: AsyncSession, settings) -> AsyncGenerator[MockGroup, None]:
     owner = await create_user(
         session=session,
         username="empty_group_owner",
@@ -196,7 +196,7 @@ async def empty_group(session: AsyncSession, settings) -> MockGroup:
 
 
 @pytest_asyncio.fixture
-async def group(session: AsyncSession, settings: Settings) -> MockGroup:
+async def group(session: AsyncSession, settings: Settings) -> AsyncGenerator[MockGroup, None]:
     owner = await create_user(
         session=session,
         username="notempty_group_owner",
@@ -240,7 +240,7 @@ async def group(session: AsyncSession, settings: Settings) -> MockGroup:
 async def mock_group(
     session: AsyncSession,
     settings: Settings,
-):
+) -> AsyncGenerator[MockGroup, None]:
     group_owner = await create_user(
         session=session,
         username=f"{secrets.token_hex(5)}_group_connection_owner",

--- a/tests/test_unit/test_queue/test_create_queue.py
+++ b/tests/test_unit/test_queue/test_create_queue.py
@@ -413,7 +413,7 @@ async def test_maintainer_plus_can_create_queues_with_the_same_name_but_diff_gro
     group_user = group.get_member_of_role(role_maintainer_plus)
 
     # Act
-    await client.post(
+    queue_1 = await client.post(
         "v1/queues",
         headers={"Authorization": f"Bearer {mock_group_user.token}"},
         json={
@@ -422,7 +422,7 @@ async def test_maintainer_plus_can_create_queues_with_the_same_name_but_diff_gro
             "group_id": mock_group.group.id,
         },
     )
-    result = await client.post(
+    queue_2 = await client.post(
         "v1/queues",
         headers={"Authorization": f"Bearer {group_user.token}"},
         json={
@@ -431,13 +431,24 @@ async def test_maintainer_plus_can_create_queues_with_the_same_name_but_diff_gro
             "group_id": group.group.id,
         },
     )
+    queue_1_json = queue_1.json()
+    queue_2_json = queue_2.json()
 
     # Assert
-    assert result.status_code == 200
-    assert result.json() == {
-        "id": result.json()["id"],
+    assert queue_1.status_code == 200
+    assert queue_1_json == {
+        "id": queue_1_json["id"],
+        "name": "New_queue",
+        "description": "Some interesting description",
+        "group_id": mock_group.group.id,
+        "slug": f"{mock_group.group.id}-New_queue",
+    }
+    assert queue_2.status_code == 200
+    assert queue_2_json == {
+        "id": queue_2_json["id"],
         "name": "New_queue",
         "description": "Some interesting description",
         "group_id": group.group.id,
         "slug": f"{group.group.id}-New_queue",
     }
+    assert queue_1_json["slug"] != queue_2_json["slug"]

--- a/tests/test_unit/test_queue/test_create_queue.py
+++ b/tests/test_unit/test_queue/test_create_queue.py
@@ -35,6 +35,7 @@ async def test_maintainer_plus_can_create_queue(
         "name": "New_queue",
         "description": "Some interesting description",
         "group_id": mock_group.group.id,
+        "slug": f"{mock_group.group.id}-New_queue",
     }
     assert result.status_code == 200
     queue = (await session.scalars(select(Queue).filter_by(id=result.json()["id"]))).one()
@@ -43,6 +44,7 @@ async def test_maintainer_plus_can_create_queue(
     assert queue.group_id == mock_group.group.id
     assert queue.name == "New_queue"
     assert queue.description == "Some interesting description"
+    assert queue.slug == f"{mock_group.group.id}-New_queue"
 
     await session.delete(queue)
     await session.commit()
@@ -71,6 +73,7 @@ async def test_superuser_can_create_queue(
         "name": "New_queue",
         "description": "Some interesting description",
         "group_id": mock_group.group.id,
+        "slug": f"{mock_group.group.id}-New_queue",
     }
     assert result.status_code == 200
     queue = (await session.scalars(select(Queue).filter_by(id=result.json()["id"]))).one()
@@ -79,6 +82,7 @@ async def test_superuser_can_create_queue(
     assert queue.group_id == mock_group.group.id
     assert queue.name == "New_queue"
     assert queue.description == "Some interesting description"
+    assert queue.slug == f"{mock_group.group.id}-New_queue"
 
     await session.delete(queue)
     await session.commit()

--- a/tests/test_unit/test_queue/test_read_queue.py
+++ b/tests/test_unit/test_queue/test_read_queue.py
@@ -28,6 +28,7 @@ async def test_group_member_can_read_queue(
         "name": group_queue.name,
         "description": group_queue.description,
         "group_id": group_queue.group_id,
+        "slug": f"{group_queue.group.id}-{group_queue.name}",
     }
     assert result.status_code == 200
 
@@ -49,6 +50,7 @@ async def test_superuser_can_read_queue(
         "name": group_queue.name,
         "description": group_queue.description,
         "group_id": group_queue.group_id,
+        "slug": f"{group_queue.group.id}-{group_queue.name}",
     }
     assert result.status_code == 200
 

--- a/tests/test_unit/test_queue/test_read_queues.py
+++ b/tests/test_unit/test_queue/test_read_queues.py
@@ -35,6 +35,7 @@ async def test_group_member_can_read_queues(
                 "name": group_queue.name,
                 "description": group_queue.description,
                 "group_id": mock_group.id,
+                "slug": f"{mock_group.id}-{group_queue.name}",
             },
         ],
         "meta": {
@@ -73,6 +74,7 @@ async def test_superuser_can_read_queues(
                 "name": group_queue.name,
                 "description": group_queue.description,
                 "group_id": mock_group.id,
+                "slug": f"{mock_group.id}-{group_queue.name}",
             },
         ],
         "meta": {
@@ -216,6 +218,7 @@ async def test_search_queues_with_query(
                 "name": group_queue.name,
                 "description": group_queue.description,
                 "group_id": mock_group.id,
+                "slug": f"{mock_group.id}-{group_queue.name}",
             },
         ],
     }

--- a/tests/test_unit/test_queue/test_update_queue.py
+++ b/tests/test_unit/test_queue/test_update_queue.py
@@ -33,6 +33,7 @@ async def test_maintainer_plus_can_update_queue(
         "name": group_queue.name,
         "description": "New description",
         "group_id": group_queue.group_id,
+        "slug": f"{group_queue.group_id}-{group_queue.name}",
     }
     assert result.status_code == 200
 
@@ -44,6 +45,7 @@ async def test_maintainer_plus_can_update_queue(
         "name": queue.name,
         "description": queue.description,
         "group_id": queue.group_id,
+        "slug": f"{queue.group_id}-{queue.name}",
     }
 
 
@@ -70,6 +72,7 @@ async def test_superuser_can_update_queue(
         "name": group_queue.name,
         "description": "New description",
         "group_id": group_queue.group_id,
+        "slug": f"{group_queue.group_id}-{group_queue.name}",
     }
 
     queue = await session.get(Queue, group_queue.id)
@@ -80,6 +83,7 @@ async def test_superuser_can_update_queue(
         "name": queue.name,
         "description": queue.description,
         "group_id": queue.group_id,
+        "slug": f"{queue.group_id}-{queue.name}",
     }
 
 

--- a/tests/test_unit/utils.py
+++ b/tests/test_unit/utils.py
@@ -77,6 +77,7 @@ async def create_queue(
         name=name,
         description=description,
         group_id=group_id,
+        slug=f"{group_id}-{name}",
     )
     session.add(queue)
     await session.commit()


### PR DESCRIPTION
## Change Summary
Previously, the `Queue` `name` field was unique among all groups. Now it is made unique within `group_id`. For this purpose, an additional read-only field `slug` is added, which is generated as `$group_id-$name`. We use this field as the name of the queue in RabbitMQ.

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.