### PR TITLE
[DOP-21350] Fix test coverage percentage

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -79,7 +79,7 @@ services:
       context: .
       target: test
     command: --loglevel=info -Q test_queue
-    entrypoint: [python, -m, celery, -A, tests.test_integration.celery_test, worker, --max-tasks-per-child=1]
+    entrypoint: [coverage, run, -m, celery, -A, tests.test_integration.celery_test, worker, --max-tasks-per-child=1]
     env_file: .env.docker
     environment:
       # CI runs tests in the worker container, so we need to turn off interaction with static files for it


### PR DESCRIPTION
## Change Summary
The [commit](https://github.com/MobileTeleSystems/syncmaster/pull/118/commits/8144b460a614fb87c173f2df9014426e56bb5a66) in [PR #118](https://github.com/MobileTeleSystems/syncmaster/pull/118) led to a 5% decrease in coverage (in particular, it was about worker module). The initial value has now been restored.

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.