### PR TITLE
[DOP-21415] Bring the JDBC connection names to the same format

### DIFF
--- a/syncmaster/schemas/v1/connections/clickhouse.py
+++ b/syncmaster/schemas/v1/connections/clickhouse.py
@@ -15,7 +15,7 @@ class ClickhouseBaseSchema(BaseModel):
 class ReadClickhouseConnectionSchema(ClickhouseBaseSchema):
     host: str
     port: int
-    database: str | None = None
+    database_name: str | None = None
     additional_params: dict = Field(default_factory=dict)
 
 
@@ -26,7 +26,7 @@ class ReadClickhouseAuthSchema(ClickhouseBaseSchema):
 class UpdateClickhouseConnectionSchema(ClickhouseBaseSchema):
     host: str | None = None
     port: int | None = None
-    database: str | None = None
+    database_name: str | None = None
     additional_params: dict | None = Field(default_factory=dict)
 
 
@@ -38,7 +38,7 @@ class UpdateClickhouseAuthSchema(ClickhouseBaseSchema):
 class CreateClickhouseConnectionSchema(ClickhouseBaseSchema):
     host: str
     port: int
-    database: str | None = None
+    database_name: str | None = None
     additional_params: dict = Field(default_factory=dict)
 
 

--- a/syncmaster/schemas/v1/connections/mssql.py
+++ b/syncmaster/schemas/v1/connections/mssql.py
@@ -15,7 +15,7 @@ class MSSQLBaseSchema(BaseModel):
 class ReadMSSQLConnectionSchema(MSSQLBaseSchema):
     host: str
     port: int
-    database: str
+    database_name: str
     additional_params: dict = Field(default_factory=dict)
 
 
@@ -26,7 +26,7 @@ class ReadMSSQLAuthSchema(MSSQLBaseSchema):
 class UpdateMSSQLConnectionSchema(MSSQLBaseSchema):
     host: str | None = None
     port: int | None = None
-    database: str | None = None
+    database_name: str | None = None
     additional_params: dict | None = Field(default_factory=dict)
 
 
@@ -38,7 +38,7 @@ class UpdateMSSQLAuthSchema(MSSQLBaseSchema):
 class CreateMSSQLConnectionSchema(MSSQLBaseSchema):
     host: str
     port: int
-    database: str
+    database_name: str
     additional_params: dict = Field(default_factory=dict)
 
 

--- a/tests/test_unit/test_connections/connection_fixtures/group_connections_fixture.py
+++ b/tests/test_unit/test_connections/connection_fixtures/group_connections_fixture.py
@@ -39,16 +39,16 @@ async def group_connections(
                     "bucket": "bucket",
                 },
             )
-        elif conn_type in [ConnectionType.POSTGRES, ConnectionType.MYSQL]:
+        elif conn_type in [
+            ConnectionType.POSTGRES,
+            ConnectionType.ORACLE,
+            ConnectionType.CLICKHOUSE,
+            ConnectionType.MSSQL,
+            ConnectionType.MYSQL,
+        ]:
             new_data.update(
                 {
                     "database_name": "database",
-                },
-            )
-        elif conn_type in [ConnectionType.ORACLE, ConnectionType.CLICKHOUSE, ConnectionType.MSSQL]:
-            new_data.update(
-                {
-                    "database": "database",
                 },
             )
 

--- a/tests/test_unit/test_connections/test_db_connection/test_create_clickhouse_connection.py
+++ b/tests/test_unit/test_connections/test_db_connection/test_create_clickhouse_connection.py
@@ -33,7 +33,7 @@ async def test_developer_plus_can_create_clickhouse_connection(
                 "type": "clickhouse",
                 "host": "127.0.0.1",
                 "port": 8123,
-                "database": "database_name",
+                "database_name": "database",
             },
             "auth_data": {
                 "type": "clickhouse",
@@ -70,7 +70,7 @@ async def test_developer_plus_can_create_clickhouse_connection(
             "type": connection.data["type"],
             "host": connection.data["host"],
             "port": connection.data["port"],
-            "database": connection.data["database"],
+            "database_name": connection.data["database_name"],
             "additional_params": connection.data["additional_params"],
         },
         "auth_data": {

--- a/tests/test_unit/test_connections/test_db_connection/test_create_mssql_connection.py
+++ b/tests/test_unit/test_connections/test_db_connection/test_create_mssql_connection.py
@@ -33,7 +33,7 @@ async def test_developer_plus_can_create_mssql_connection(
                 "type": "mssql",
                 "host": "127.0.0.1",
                 "port": 1433,
-                "database": "database_name",
+                "database_name": "database",
             },
             "auth_data": {
                 "type": "mssql",
@@ -70,7 +70,7 @@ async def test_developer_plus_can_create_mssql_connection(
             "type": connection.data["type"],
             "host": connection.data["host"],
             "port": connection.data["port"],
-            "database": connection.data["database"],
+            "database_name": connection.data["database_name"],
             "additional_params": connection.data["additional_params"],
         },
         "auth_data": {

--- a/tests/test_unit/test_connections/test_db_connection/test_update_clickhouse_connection.py
+++ b/tests/test_unit/test_connections/test_db_connection/test_update_clickhouse_connection.py
@@ -41,7 +41,7 @@ async def test_developer_plus_can_update_clickhouse_connection(
             "connection_data": {
                 "type": "clickhouse",
                 "host": "127.0.1.1",
-                "database": "new_name",
+                "database_name": "new_name",
             },
             "auth_data": {
                 "type": "clickhouse",
@@ -61,7 +61,7 @@ async def test_developer_plus_can_update_clickhouse_connection(
             "type": group_connection.data["type"],
             "host": "127.0.1.1",
             "port": group_connection.data["port"],
-            "database": "new_name",
+            "database_name": "new_name",
             "additional_params": {},
         },
         "auth_data": {

--- a/tests/test_unit/test_connections/test_db_connection/test_update_mssql_connection.py
+++ b/tests/test_unit/test_connections/test_db_connection/test_update_mssql_connection.py
@@ -14,7 +14,7 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.backend, pytest.mark.mssql]
                 "type": "mssql",
                 "host": "127.0.0.1",
                 "port": 1433,
-                "database": "name",
+                "database_name": "name",
             },
             {
                 "type": "mssql",
@@ -42,7 +42,7 @@ async def test_developer_plus_can_update_mssql_connection(
             "connection_data": {
                 "type": "mssql",
                 "host": "127.0.1.1",
-                "database": "new_name",
+                "database_name": "new_name",
             },
             "auth_data": {
                 "type": "mssql",
@@ -62,7 +62,7 @@ async def test_developer_plus_can_update_mssql_connection(
             "type": group_connection.data["type"],
             "host": "127.0.1.1",
             "port": group_connection.data["port"],
-            "database": "new_name",
+            "database_name": "new_name",
             "additional_params": {},
         },
         "auth_data": {


### PR DESCRIPTION
## Change Summary
Unified the database field naming convention across all JDBC types by using `database_name`.

## Checklist

* [ ] Commit message and PR title is comprehensive
* [ ] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [ ] My PR is ready to review.