### PR TITLE
[DOP-19926] Grant read-only rights to the previous group owner when ownership is transferred

### DIFF
--- a/docs/changelog/next_release/135.feature.rst
+++ b/docs/changelog/next_release/135.feature.rst
@@ -1,0 +1,1 @@
+Grant read-only rights for the previous group owner when ownership is transferred

--- a/syncmaster/backend/handler.py
+++ b/syncmaster/backend/handler.py
@@ -22,6 +22,7 @@ from syncmaster.exceptions.connection import (
 from syncmaster.exceptions.credentials import AuthDataNotFoundError
 from syncmaster.exceptions.group import (
     AlreadyIsGroupMemberError,
+    AlreadyIsGroupOwnerError,
     AlreadyIsNotGroupMemberError,
     GroupAdminNotFoundError,
     GroupAlreadyExistsError,
@@ -189,6 +190,14 @@ async def syncmsater_exception_handler(request: Request, exc: SyncmasterError):
     if isinstance(exc, AlreadyIsGroupMemberError):
         content.code = "conflict"
         content.message = "User already is group member"
+        return exception_json_response(
+            status=status.HTTP_409_CONFLICT,
+            content=content,
+        )
+
+    if isinstance(exc, AlreadyIsGroupOwnerError):
+        content.code = "conflict"
+        content.message = "User already is group owner"
         return exception_json_response(
             status=status.HTTP_409_CONFLICT,
             content=content,

--- a/syncmaster/db/repositories/group.py
+++ b/syncmaster/db/repositories/group.py
@@ -337,6 +337,15 @@ class GroupRepository(Repository[Group]):
 
         return Permission.READ
 
+    async def get_user_group(self, group_id: int, user_id: int) -> UserGroup | None:
+        return await self._session.get(
+            UserGroup,
+            {
+                "group_id": group_id,
+                "user_id": user_id,
+            },
+        )
+
     async def delete_user(
         self,
         group_id: int,

--- a/syncmaster/exceptions/group.py
+++ b/syncmaster/exceptions/group.py
@@ -23,5 +23,9 @@ class AlreadyIsNotGroupMemberError(SyncmasterError):
     pass
 
 
+class AlreadyIsGroupOwnerError(SyncmasterError):
+    pass
+
+
 class GroupNotFoundError(SyncmasterError):
     pass

--- a/tests/test_unit/test_connections/connection_fixtures/group_connections_fixture.py
+++ b/tests/test_unit/test_connections/connection_fixtures/group_connections_fixture.py
@@ -41,7 +41,6 @@ async def group_connections(
             )
         elif conn_type in [
             ConnectionType.POSTGRES,
-            ConnectionType.ORACLE,
             ConnectionType.CLICKHOUSE,
             ConnectionType.MSSQL,
             ConnectionType.MYSQL,

--- a/tests/test_unit/test_groups/test_add_user_to_group.py
+++ b/tests/test_unit/test_groups/test_add_user_to_group.py
@@ -337,6 +337,31 @@ async def test_owner_add_unknown_user_to_group_error(
     }
 
 
+async def test_add_exiting_owner_as_a_group_member(
+    client: AsyncClient,
+    empty_group: MockGroup,
+    role_maintainer_or_below: UserTestRoles,
+):
+    user = empty_group.get_member_of_role(UserTestRoles.Owner)
+
+    result = await client.post(
+        f"v1/groups/{empty_group.id}/users/{empty_group.owner_id}",
+        headers={"Authorization": f"Bearer {user.token}"},
+        json={
+            "role": role_maintainer_or_below,
+        },
+    )
+
+    assert result.status_code == 409
+    assert result.json() == {
+        "error": {
+            "code": "conflict",
+            "message": "User already is group owner",
+            "details": None,
+        },
+    }
+
+
 async def test_superuser_add_user_to_unknown_group_error(
     client: AsyncClient,
     superuser: MockUser,


### PR DESCRIPTION
## Change Summary
Updated group ownership transfer logic: the previous owner now retains read-only access to the group after transferring ownership. The new owner retains the ability to revoke this access if needed.
Added a restriction to the `POST /groups/{group_id}/users/{user_id}` endpoint to prevent assigning a role to a user who is already a group owner.

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.