### PR TITLE
[DOP-21442] Add Excel API schema

### DIFF
--- a/docs/changelog/next_release/139.feature.rst
+++ b/docs/changelog/next_release/139.feature.rst
@@ -1,0 +1,1 @@
+Add Excel API schema

--- a/syncmaster/schemas/v1/__init__.py
+++ b/syncmaster/schemas/v1/__init__.py
@@ -36,7 +36,7 @@ from syncmaster.schemas.v1.transfers.db import (
     PostgresReadTransferSourceAndTarget,
     ReadDBTransfer,
 )
-from syncmaster.schemas.v1.transfers.file_format import CSV, JSON, JSONLine
+from syncmaster.schemas.v1.transfers.file_format import CSV, JSON, Excel, JSONLine
 from syncmaster.schemas.v1.transfers.run import (
     CreateRunSchema,
     ReadRunSchema,

--- a/syncmaster/schemas/v1/file_formats.py
+++ b/syncmaster/schemas/v1/file_formats.py
@@ -5,3 +5,4 @@ from typing import Literal
 CSV_FORMAT = Literal["csv"]
 JSONLINE_FORMAT = Literal["jsonline"]
 JSON_FORMAT = Literal["json"]
+EXCEL_FORMAT = Literal["excel"]

--- a/syncmaster/schemas/v1/transfers/file/base.py
+++ b/syncmaster/schemas/v1/transfers/file/base.py
@@ -7,20 +7,20 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
-from syncmaster.schemas.v1.transfers.file_format import CSV, JSON, JSONLine
+from syncmaster.schemas.v1.transfers.file_format import CSV, JSON, Excel, JSONLine
 
 
 # At the moment the ReadTransferSourceParams and ReadTransferTargetParams
 # classes are identical but may change in the future
 class ReadFileTransferSource(BaseModel):
     directory_path: str
-    file_format: CSV | JSONLine | JSON = Field(..., discriminator="type")
+    file_format: CSV | JSONLine | JSON | Excel = Field(..., discriminator="type")
     options: dict[str, Any]
 
 
 class ReadFileTransferTarget(BaseModel):
     directory_path: str
-    file_format: CSV | JSONLine = Field(..., discriminator="type")  # JSON format is not supported for writing
+    file_format: CSV | JSONLine | Excel = Field(..., discriminator="type")  # JSON format is not supported for writing
     options: dict[str, Any]
 
 
@@ -28,7 +28,7 @@ class ReadFileTransferTarget(BaseModel):
 # classes are identical but may change in the future
 class CreateFileTransferSource(BaseModel):
     directory_path: str
-    file_format: CSV | JSONLine | JSON = Field(..., discriminator="type")
+    file_format: CSV | JSONLine | JSON | Excel = Field(..., discriminator="type")
     options: dict[str, Any] = Field(default_factory=dict)
 
     class Config:
@@ -44,7 +44,7 @@ class CreateFileTransferSource(BaseModel):
 
 class CreateFileTransferTarget(BaseModel):
     directory_path: str
-    file_format: CSV | JSONLine = Field(..., discriminator="type")  # JSON FORMAT IS NOT SUPPORTED AS A TARGET !
+    file_format: CSV | JSONLine | Excel = Field(..., discriminator="type")  # JSON FORMAT IS NOT SUPPORTED AS A TARGET !
     options: dict[str, Any] = Field(default_factory=dict)
 
     class Config:

--- a/syncmaster/schemas/v1/transfers/file_format.py
+++ b/syncmaster/schemas/v1/transfers/file_format.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from pydantic import BaseModel
 
-from syncmaster.schemas.v1.file_formats import CSV_FORMAT, JSON_FORMAT, JSONLINE_FORMAT
+from syncmaster.schemas.v1.file_formats import (
+    CSV_FORMAT,
+    EXCEL_FORMAT,
+    JSON_FORMAT,
+    JSONLINE_FORMAT,
+)
 
 
 class CSV(BaseModel):
@@ -27,3 +32,9 @@ class JSON(BaseModel):
     type: JSON_FORMAT
     encoding: str = "utf-8"
     line_sep: str = "\n"
+
+
+class Excel(BaseModel):
+    type: EXCEL_FORMAT
+    include_header: bool
+    start_cell: str | None = None

--- a/tests/test_unit/test_transfers/test_file_transfers/test_create_transfer.py
+++ b/tests/test_unit/test_transfers/test_file_transfers/test_create_transfer.py
@@ -28,6 +28,24 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.backend]
             "directory_path": "/some/pure/path",
             "file_format": {
                 "type": "csv",
+                "delimiter": ",",
+                "encoding": "utf-8",
+                "quote": '"',
+                "escape": "\\",
+                "header": False,
+                "line_sep": "\n",
+            },
+            "options": {
+                "some": "option",
+            },
+        },
+        {
+            "type": "s3",
+            "directory_path": "/some/excel/path",
+            "file_format": {
+                "type": "excel",
+                "include_header": True,
+                "start_cell": "A1",
             },
             "options": {
                 "some": "option",
@@ -94,11 +112,26 @@ async def test_developer_plus_can_create_s3_transfer(
         "queue_id": transfer.queue_id,
     }
 
+    expected_file_formats = {
+        "csv": {
+            "delimiter": ",",
+            "encoding": "utf-8",
+            "quote": '"',
+            "escape": "\\",
+            "header": False,
+            "line_sep": "\n",
+        },
+        "excel": {
+            "include_header": True,
+            "start_cell": "A1",
+        },
+    }
+
     for params in (transfer.source_params, transfer.target_params):
-        assert params["type"] == "s3"
-        assert params["directory_path"] == "/some/pure/path"
-        assert params["file_format"]["type"] == "csv"
+        assert params["type"] == target_source_params["type"]
+        assert params["directory_path"] == target_source_params["directory_path"]
         assert params["options"] == {"some": "option"}
+        assert params["file_format"] == expected_file_formats[params["type"]]
 
 
 @pytest.mark.parametrize(
@@ -119,6 +152,15 @@ async def test_developer_plus_can_create_s3_transfer(
             "directory_path": "/some/pure/path",
             "file_format": {
                 "type": "csv",
+            },
+        },
+        {
+            "type": "hdfs",
+            "directory_path": "/some/excel/path",
+            "file_format": {
+                "type": "excel",
+                "include_header": True,
+                "start_cell": "A1",
             },
         },
     ],
@@ -183,10 +225,27 @@ async def test_developer_plus_can_create_hdfs_transfer(
         "queue_id": transfer.queue_id,
     }
 
+    expected_file_formats = {
+        "csv": {
+            "type": "csv",
+            "delimiter": ",",
+            "encoding": "utf-8",
+            "quote": '"',
+            "escape": "\\",
+            "header": False,
+            "line_sep": "\n",
+        },
+        "excel": {
+            "type": "excel",
+            "include_header": True,
+            "start_cell": "A1",
+        },
+    }
+
     for params in (transfer.source_params, transfer.target_params):
-        assert params["type"] == "hdfs"
-        assert params["directory_path"] == "/some/pure/path"
-        assert params["file_format"]["type"] == "csv"
+        assert params["type"] == target_source_params["type"]
+        assert params["directory_path"] == target_source_params["directory_path"]
+        assert params["file_format"] == expected_file_formats[params["file_format"]["type"]]
         assert params["options"] == {}
 
 
@@ -209,6 +268,14 @@ async def test_developer_plus_can_create_hdfs_transfer(
             "directory_path": "some/path",
             "file_format": {
                 "type": "csv",
+            },
+        },
+        {
+            "type": "s3",
+            "directory_path": "some/path",
+            "file_format": {
+                "type": "excel",
+                "include_header": True,
             },
         },
     ],

--- a/tests/test_unit/test_transfers/test_file_transfers/test_read_transfer.py
+++ b/tests/test_unit/test_transfers/test_file_transfers/test_read_transfer.py
@@ -23,6 +23,16 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.backend]
             },
             "options": {},
         },
+        {
+            "type": "s3",
+            "directory_path": "/some/excel/path",
+            "file_format": {
+                "type": "excel",
+                "include_header": True,
+                "start_cell": "A1",
+            },
+            "options": {},
+        },
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/test_unit/test_transfers/test_file_transfers/test_update_transfer.py
+++ b/tests/test_unit/test_transfers/test_file_transfers/test_update_transfer.py
@@ -23,6 +23,16 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.backend]
             },
             "options": {},
         },
+        {
+            "type": "s3",
+            "directory_path": "/some/excel/path",
+            "file_format": {
+                "type": "excel",
+                "include_header": True,
+                "start_cell": "A1",
+            },
+            "options": {},
+        },
     ],
 )
 @pytest.mark.parametrize(
@@ -54,7 +64,7 @@ async def test_developer_plus_can_update_s3_transfer(
             "source_params": {
                 "type": "s3",
                 "directory_path": "/some/new/test/directory",
-                "file_format": {"type": "jsonline"},
+                "file_format": create_transfer_data["file_format"],
                 "options": {"some": "option"},
             },
         },
@@ -65,14 +75,11 @@ async def test_developer_plus_can_update_s3_transfer(
     source_params.update(
         {
             "directory_path": "/some/new/test/directory",
-            "file_format": {
-                "encoding": "utf-8",
-                "line_sep": "\n",
-                "type": "jsonline",
-            },
+            "file_format": create_transfer_data["file_format"],
             "options": {"some": "option"},
         },
     )
+
     # Assert
     assert result.status_code == 200
     assert result.json() == {


### PR DESCRIPTION
## Change Summary

- Added API schemas for creating and updating Transfers with `file_format=excel`.
- Included parameters for the Excel format:
  - `include_header: bool` (applicable for both reading and writing).
  - `start_cell: str | None` (applicable for both reading and writing).

## Checklist

* [ ] Commit message and PR title is comprehensive
* [ ] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [ ] My PR is ready to review.