### PR TITLE
[DOP-21976] Add compression options for XML

### DIFF
--- a/docs/changelog/next_release/161.feature.rst
+++ b/docs/changelog/next_release/161.feature.rst
@@ -1,0 +1,1 @@
+Add compression options to XML file format

--- a/syncmaster/schemas/v1/transfers/file_format.py
+++ b/syncmaster/schemas/v1/transfers/file_format.py
@@ -49,6 +49,14 @@ class CSVCompression(str, Enum):
     DEFLATE = "deflate"
 
 
+class XMLCompression(str, Enum):
+    NONE = "none"
+    BZIP2 = "bzip2"
+    GZIP = "gzip"
+    LZ4 = "lz4"
+    SNAPPY = "snappy"
+
+
 class CSV(BaseModel):
     type: CSV_FORMAT
     delimiter: str = ","
@@ -84,6 +92,7 @@ class XML(BaseModel):
     type: XML_FORMAT
     root_tag: str
     row_tag: str
+    compression: XMLCompression = XMLCompression.GZIP
 
 
 class ORC(BaseModel):

--- a/tests/test_integration/test_run_transfer/test_hdfs.py
+++ b/tests/test_integration/test_run_transfer/test_hdfs.py
@@ -229,8 +229,8 @@ async def test_run_transfer_hdfs_to_postgres(
             id="parquet",
         ),
         pytest.param(
-            ("xml", {}),
-            "without_compression",
+            ("xml", {"compression": "snappy"}),
+            "with_compression",
             id="xml",
         ),
     ],

--- a/tests/test_integration/test_run_transfer/test_s3.py
+++ b/tests/test_integration/test_run_transfer/test_s3.py
@@ -230,7 +230,7 @@ async def test_run_transfer_s3_to_postgres(
             id="parquet",
         ),
         pytest.param(
-            ("xml", {}),
+            ("xml", {"compression": "none"}),
             "without_compression",
             id="xml",
         ),

--- a/tests/test_unit/test_transfers/test_file_transfers/test_create_transfer.py
+++ b/tests/test_unit/test_transfers/test_file_transfers/test_create_transfer.py
@@ -59,6 +59,7 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.backend]
                 "type": "xml",
                 "root_tag": "data",
                 "row_tag": "record",
+                "compression": "lz4",
             },
             "options": {
                 "some": "option",
@@ -166,6 +167,7 @@ async def test_developer_plus_can_create_s3_transfer(
             "type": "xml",
             "root_tag": "data",
             "row_tag": "record",
+            "compression": "lz4",
         },
         "orc": {
             "type": "orc",
@@ -221,6 +223,7 @@ async def test_developer_plus_can_create_s3_transfer(
                 "type": "xml",
                 "root_tag": "data",
                 "row_tag": "record",
+                "compression": "bzip2",
             },
         },
         {
@@ -320,6 +323,7 @@ async def test_developer_plus_can_create_hdfs_transfer(
             "type": "xml",
             "root_tag": "data",
             "row_tag": "record",
+            "compression": "bzip2",
         },
         "orc": {
             "type": "orc",

--- a/tests/test_unit/test_transfers/test_file_transfers/test_read_transfer.py
+++ b/tests/test_unit/test_transfers/test_file_transfers/test_read_transfer.py
@@ -41,6 +41,7 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.backend]
                 "type": "xml",
                 "root_tag": "data",
                 "row_tag": "record",
+                "compression": "bzip2",
             },
             "options": {},
         },

--- a/tests/test_unit/test_transfers/test_file_transfers/test_update_transfer.py
+++ b/tests/test_unit/test_transfers/test_file_transfers/test_update_transfer.py
@@ -41,6 +41,7 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.backend]
                 "type": "xml",
                 "root_tag": "data",
                 "row_tag": "record",
+                "compression": "bzip2",
             },
             "options": {},
         },


### PR DESCRIPTION
## Change Summary

Added a compression parameter to the write settings for XML file format with supported compression values: [XML](https://github.com/databricks/spark-xml?tab=readme-ov-file#features)
Added integration tests to validate compression functionality.

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.