### PR TITLE
[DOP-21952] Extend auth token lifetime in the fixture

### DIFF
--- a/tests/test_unit/test_auth/auth_fixtures/keycloak_fixture.py
+++ b/tests/test_unit/test_auth/auth_fixtures/keycloak_fixture.py
@@ -46,7 +46,7 @@ def get_public_key_pem(public_key):
 
 @pytest.fixture
 def create_session_cookie(rsa_keys, settings):
-    def _create_session_cookie(user, expire_in_msec=1000) -> str:
+    def _create_session_cookie(user, expire_in_msec=5000) -> str:
         private_pem = rsa_keys["private_pem"]
         session_secret_key = settings.server.session.secret_key
 


### PR DESCRIPTION
## Change Summary

Previously, the auth unit test was flaky in CI due to access token expiration. Its lifetime has now been extended from 1 to 5 seconds. The unit tests were rerun several times and passed successfully.

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.