### PR TITLE
[DOP-22350] Add transformations for Transfers with dataframe column filtering

### DIFF
--- a/docs/changelog/next_release/186.feature.rst
+++ b/docs/changelog/next_release/186.feature.rst
@@ -1,0 +1,1 @@
+Add transformations for **Transfers** with dataframe column filtering

--- a/syncmaster/schemas/v1/transfers/__init__.py
+++ b/syncmaster/schemas/v1/transfers/__init__.py
@@ -29,6 +29,9 @@ from syncmaster.schemas.v1.transfers.file.s3 import (
     S3ReadTransferTarget,
 )
 from syncmaster.schemas.v1.transfers.strategy import FullStrategy, IncrementalStrategy
+from syncmaster.schemas.v1.transfers.transformations.dataframe_columns_filter import (
+    DataframeColumnsFilter,
+)
 from syncmaster.schemas.v1.transfers.transformations.dataframe_rows_filter import (
     DataframeRowsFilter,
 )
@@ -102,7 +105,7 @@ UpdateTransferSchemaTarget = (
     | None
 )
 
-TransformationSchema = DataframeRowsFilter
+TransformationSchema = DataframeRowsFilter | DataframeColumnsFilter
 
 
 class CopyTransferSchema(BaseModel):

--- a/syncmaster/schemas/v1/transfers/transformations/dataframe_columns_filter.py
+++ b/syncmaster/schemas/v1/transfers/transformations/dataframe_columns_filter.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2023-2024 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field
+
+from syncmaster.schemas.v1.transformation_types import DATAFRAME_COLUMNS_FILTER
+
+
+class BaseColumnsFilter(BaseModel):
+    field: str
+
+
+class IncludeFilter(BaseColumnsFilter):
+    type: Literal["include"]
+
+
+class RenameFilter(BaseColumnsFilter):
+    type: Literal["rename"]
+    to: str
+
+
+class CastFilter(BaseColumnsFilter):
+    type: Literal["cast"]
+    as_type: str
+
+
+ColumnsFilter = IncludeFilter | RenameFilter | CastFilter
+
+
+class DataframeColumnsFilter(BaseModel):
+    type: DATAFRAME_COLUMNS_FILTER
+    filters: list[Annotated[ColumnsFilter, Field(..., discriminator="type")]] = Field(default_factory=list)

--- a/syncmaster/schemas/v1/transfers/transformations/dataframe_rows_filter.py
+++ b/syncmaster/schemas/v1/transfers/transformations/dataframe_rows_filter.py
@@ -7,74 +7,74 @@ from pydantic import BaseModel, Field
 from syncmaster.schemas.v1.transformation_types import DATAFRAME_ROWS_FILTER
 
 
-class BaseRowFilter(BaseModel):
+class BaseRowsFilter(BaseModel):
     field: str
 
 
-class IsNullFilter(BaseRowFilter):
+class IsNullFilter(BaseRowsFilter):
     type: Literal["is_null"]
 
 
-class IsNotNullFilter(BaseRowFilter):
+class IsNotNullFilter(BaseRowsFilter):
     type: Literal["is_not_null"]
 
 
-class EqualFilter(BaseRowFilter):
+class EqualFilter(BaseRowsFilter):
     type: Literal["equal"]
     value: str
 
 
-class NotEqualFilter(BaseRowFilter):
+class NotEqualFilter(BaseRowsFilter):
     type: Literal["not_equal"]
     value: str
 
 
-class GreaterThanFilter(BaseRowFilter):
+class GreaterThanFilter(BaseRowsFilter):
     type: Literal["greater_than"]
     value: str
 
 
-class GreaterOrEqualFilter(BaseRowFilter):
+class GreaterOrEqualFilter(BaseRowsFilter):
     type: Literal["greater_or_equal"]
     value: str
 
 
-class LessThanFilter(BaseRowFilter):
+class LessThanFilter(BaseRowsFilter):
     type: Literal["less_than"]
     value: str
 
 
-class LessOrEqualFilter(BaseRowFilter):
+class LessOrEqualFilter(BaseRowsFilter):
     type: Literal["less_or_equal"]
     value: str
 
 
-class LikeFilter(BaseRowFilter):
+class LikeFilter(BaseRowsFilter):
     type: Literal["like"]
     value: str
 
 
-class ILikeFilter(BaseRowFilter):
+class ILikeFilter(BaseRowsFilter):
     type: Literal["ilike"]
     value: str
 
 
-class NotLikeFilter(BaseRowFilter):
+class NotLikeFilter(BaseRowsFilter):
     type: Literal["not_like"]
     value: str
 
 
-class NotILikeFilter(BaseRowFilter):
+class NotILikeFilter(BaseRowsFilter):
     type: Literal["not_ilike"]
     value: str
 
 
-class RegexpFilter(BaseRowFilter):
+class RegexpFilter(BaseRowsFilter):
     type: Literal["regexp"]
     value: str
 
 
-RowFilter = (
+RowsFilter = (
     IsNullFilter
     | IsNotNullFilter
     | EqualFilter
@@ -93,4 +93,4 @@ RowFilter = (
 
 class DataframeRowsFilter(BaseModel):
     type: DATAFRAME_ROWS_FILTER
-    filters: list[Annotated[RowFilter, Field(..., discriminator="type")]] = Field(default_factory=list)
+    filters: list[Annotated[RowsFilter, Field(..., discriminator="type")]] = Field(default_factory=list)

--- a/syncmaster/schemas/v1/transformation_types.py
+++ b/syncmaster/schemas/v1/transformation_types.py
@@ -3,3 +3,4 @@
 from typing import Literal
 
 DATAFRAME_ROWS_FILTER = Literal["dataframe_rows_filter"]
+DATAFRAME_COLUMNS_FILTER = Literal["dataframe_columns_filter"]

--- a/syncmaster/worker/handlers/db/clickhouse.py
+++ b/syncmaster/worker/handlers/db/clickhouse.py
@@ -64,10 +64,10 @@ class ClickhouseHandler(DBHandler):
             df = df.withColumnRenamed(column_name, column_name.lower())
         return df
 
-    def _make_filter_expression(self, filters: list[dict]) -> str | None:
+    def _make_rows_filter_expression(self, filters: list[dict]) -> str | None:
         expressions = []
         for filter in filters:
-            field = f'"{filter["field"]}"'
+            field = self._quote_field(filter["field"])
             op = self._operators[filter["type"]]
             value = filter.get("value")
 

--- a/syncmaster/worker/handlers/db/hive.py
+++ b/syncmaster/worker/handlers/db/hive.py
@@ -40,11 +40,11 @@ class HiveHandler(DBHandler):
             df = df.withColumnRenamed(column_name, column_name.lower())
         return df
 
-    def _make_filter_expression(self, filters: list[dict]) -> str | None:
+    def _make_rows_filter_expression(self, filters: list[dict]) -> str | None:
         expressions = []
         for filter in filters:
             op = self._operators[filter["type"]]
-            field = f"`{filter["field"]}`"
+            field = self._quote_field(filter["field"])
             value = filter.get("value")
 
             if value is None:
@@ -59,3 +59,7 @@ class HiveHandler(DBHandler):
                 expressions.append(f"{field} {op} '{value}'")
 
         return " AND ".join(expressions) or None
+
+    @staticmethod
+    def _quote_field(field):
+        return f"`{field}`"

--- a/syncmaster/worker/handlers/db/mssql.py
+++ b/syncmaster/worker/handlers/db/mssql.py
@@ -43,11 +43,11 @@ class MSSQLHandler(DBHandler):
             df = df.withColumnRenamed(column_name, column_name.lower())
         return df
 
-    def _make_filter_expression(self, filters: list[dict]) -> str | None:
+    def _make_rows_filter_expression(self, filters: list[dict]) -> str | None:
         expressions = []
         for filter in filters:
             op = self._operators[filter["type"]]
-            field = f'"{filter["field"]}"'
+            field = self._quote_field(filter["field"])
             value = filter.get("value")
 
             if value is None:

--- a/syncmaster/worker/handlers/db/mysql.py
+++ b/syncmaster/worker/handlers/db/mysql.py
@@ -40,11 +40,11 @@ class MySQLHandler(DBHandler):
             df = df.withColumnRenamed(column_name, column_name.lower())
         return df
 
-    def _make_filter_expression(self, filters: list[dict]) -> str | None:
+    def _make_rows_filter_expression(self, filters: list[dict]) -> str | None:
         expressions = []
         for filter in filters:
             op = self._operators[filter["type"]]
-            field = f"`{filter["field"]}`"
+            field = self._quote_field(filter["field"])
             value = filter.get("value")
 
             if value is None:
@@ -59,3 +59,7 @@ class MySQLHandler(DBHandler):
                 expressions.append(f"{field} {op} '{value}'")
 
         return " AND ".join(expressions) or None
+
+    @staticmethod
+    def _quote_field(field: str) -> str:
+        return f"`{field}`"

--- a/syncmaster/worker/handlers/db/oracle.py
+++ b/syncmaster/worker/handlers/db/oracle.py
@@ -42,10 +42,10 @@ class OracleHandler(DBHandler):
             df = df.withColumnRenamed(column_name, column_name.upper())
         return df
 
-    def _make_filter_expression(self, filters: list[dict]) -> str | None:
+    def _make_rows_filter_expression(self, filters: list[dict]) -> str | None:
         expressions = []
         for filter in filters:
-            field = f'"{filter["field"]}"'
+            field = self._quote_field(filter["field"])
             op = self._operators[filter["type"]]
             value = filter.get("value")
 

--- a/syncmaster/worker/handlers/db/postgres.py
+++ b/syncmaster/worker/handlers/db/postgres.py
@@ -41,10 +41,10 @@ class PostgresHandler(DBHandler):
             df = df.withColumnRenamed(column_name, column_name.lower())
         return df
 
-    def _make_filter_expression(self, filters: list[dict]) -> str | None:
+    def _make_rows_filter_expression(self, filters: list[dict]) -> str | None:
         expressions = []
         for filter in filters:
-            field = f'"{filter["field"]}"'
+            field = self._quote_field(filter["field"])
             op = self._operators[filter["type"]]
             value = filter.get("value")
 

--- a/syncmaster/worker/handlers/file/s3.py
+++ b/syncmaster/worker/handlers/file/s3.py
@@ -47,8 +47,12 @@ class S3Handler(FileHandler):
         )
         df = reader.run()
 
-        filter_expression = self._get_filter_expression()
-        if filter_expression:
-            df = df.where(filter_expression)
+        rows_filter_expression = self._get_rows_filter_expression()
+        if rows_filter_expression:
+            df = df.where(rows_filter_expression)
+
+        columns_filter_expressions = self._get_columns_filter_expressions()
+        if columns_filter_expressions:
+            df = df.selectExpr(*columns_filter_expressions)
 
         return df

--- a/tests/test_integration/test_run_transfer/conftest.py
+++ b/tests/test_integration/test_run_transfer/conftest.py
@@ -1317,7 +1317,8 @@ def init_df_with_mixed_column_naming(spark: SparkSession) -> DataFrame:
 
 
 @pytest.fixture
-def dataframe_rows_filter_transformations():
+def dataframe_rows_filter_transformations(source_type: str):
+    regexp_value = "[0-9!@#$.,;_]%" if source_type == "mssql" else "^[^+].*"  # MSSQL regexp is limited
     return [
         {
             "type": "dataframe_rows_filter",
@@ -1344,7 +1345,7 @@ def dataframe_rows_filter_transformations():
                 {
                     "type": "regexp",
                     "field": "PHONE_NUMBER",
-                    "value": "^[^+].*",
+                    "value": regexp_value,
                 },
             ],
         },
@@ -1353,10 +1354,69 @@ def dataframe_rows_filter_transformations():
 
 @pytest.fixture
 def expected_dataframe_rows_filter():
-    return lambda df: (
+    return lambda df, source_type: df.filter(
         df["BIRTH_DATE"].isNotNull()
         & (df["NUMBER"] <= "25")
         & (~df["REGION"].like("%port"))
         & (~df["REGION"].ilike("new%"))
-        & (df["PHONE_NUMBER"].rlike("^[^+].*"))
+        & (df["PHONE_NUMBER"].rlike("^[0-9!@#$.,;_]" if source_type == "mssql" else "^[^+].*")),
+    )
+
+
+@pytest.fixture
+def dataframe_columns_filter_transformations(source_type: str):
+    string_types_per_source_type = {
+        "postgres": "VARCHAR(10)",
+        "oracle": "VARCHAR2(10)",
+        "clickhouse": "VARCHAR(10)",
+        "mysql": "CHAR",
+        "mssql": "VARCHAR(10)",
+        "hive": "VARCHAR(10)",
+        "s3": "STRING",
+        "hdfs": "STRING",
+    }
+    return [
+        {
+            "type": "dataframe_columns_filter",
+            "filters": [
+                {
+                    "type": "include",
+                    "field": "ID",
+                },
+                {
+                    "type": "include",
+                    "field": "REGION",
+                },
+                {
+                    "type": "include",
+                    "field": "PHONE_NUMBER",
+                },
+                {
+                    "type": "rename",
+                    "field": "REGION",
+                    "to": "REGION2",
+                },
+                {
+                    "type": "cast",
+                    "field": "NUMBER",
+                    "as_type": string_types_per_source_type[source_type],
+                },
+                {
+                    "type": "include",
+                    "field": "REGISTERED_AT",
+                },
+            ],
+        },
+    ]
+
+
+@pytest.fixture
+def expected_dataframe_columns_filter():
+    return lambda df, source_type: df.selectExpr(
+        "ID",
+        "REGION",
+        "PHONE_NUMBER",
+        "REGION AS REGION2",
+        "CAST(NUMBER AS STRING) AS NUMBER",
+        "REGISTERED_AT",
     )

--- a/tests/test_integration/test_run_transfer/test_clickhouse.py
+++ b/tests/test_integration/test_run_transfer/test_clickhouse.py
@@ -82,11 +82,17 @@ async def clickhouse_to_postgres(
 
 
 @pytest.mark.parametrize(
-    "transformations, expected_filter",
+    "source_type, transformations, expected_filter",
     [
         (
+            "clickhouse",
             lf("dataframe_rows_filter_transformations"),
             lf("expected_dataframe_rows_filter"),
+        ),
+        (
+            "clickhouse",
+            lf("dataframe_columns_filter_transformations"),
+            lf("expected_dataframe_columns_filter"),
         ),
     ],
 )
@@ -97,6 +103,7 @@ async def test_run_transfer_postgres_to_clickhouse(
     prepare_clickhouse,
     init_df: DataFrame,
     postgres_to_clickhouse: Transfer,
+    source_type,
     transformations,
     expected_filter,
 ):
@@ -104,7 +111,7 @@ async def test_run_transfer_postgres_to_clickhouse(
     _, fill_with_data = prepare_postgres
     fill_with_data(init_df)
     clickhouse, _ = prepare_clickhouse
-    init_df = init_df.where(expected_filter(init_df))
+    init_df = expected_filter(init_df, source_type)
 
     # Act
     result = await client.post(
@@ -192,11 +199,17 @@ async def test_run_transfer_postgres_to_clickhouse_mixed_naming(
 
 
 @pytest.mark.parametrize(
-    "transformations, expected_filter",
+    "source_type, transformations, expected_filter",
     [
         (
+            "clickhouse",
             lf("dataframe_rows_filter_transformations"),
             lf("expected_dataframe_rows_filter"),
+        ),
+        (
+            "clickhouse",
+            lf("dataframe_columns_filter_transformations"),
+            lf("expected_dataframe_columns_filter"),
         ),
     ],
 )
@@ -206,6 +219,7 @@ async def test_run_transfer_clickhouse_to_postgres(
     prepare_clickhouse,
     prepare_postgres,
     init_df: DataFrame,
+    source_type,
     transformations,
     expected_filter,
     clickhouse_to_postgres: Transfer,
@@ -214,7 +228,7 @@ async def test_run_transfer_clickhouse_to_postgres(
     _, fill_with_data = prepare_clickhouse
     fill_with_data(init_df)
     postgres, _ = prepare_postgres
-    init_df = init_df.where(expected_filter(init_df))
+    init_df = expected_filter(init_df, source_type)
 
     # Act
     result = await client.post(

--- a/tests/test_integration/test_run_transfer/test_hive.py
+++ b/tests/test_integration/test_run_transfer/test_hive.py
@@ -180,11 +180,17 @@ async def test_run_transfer_postgres_to_hive_mixed_naming(
 
 
 @pytest.mark.parametrize(
-    "transformations, expected_filter",
+    "source_type, transformations, expected_filter",
     [
         (
+            "hive",
             lf("dataframe_rows_filter_transformations"),
             lf("expected_dataframe_rows_filter"),
+        ),
+        (
+            "hive",
+            lf("dataframe_columns_filter_transformations"),
+            lf("expected_dataframe_columns_filter"),
         ),
     ],
 )
@@ -195,6 +201,7 @@ async def test_run_transfer_hive_to_postgres(
     prepare_postgres,
     init_df: DataFrame,
     hive_to_postgres: Transfer,
+    source_type,
     transformations,
     expected_filter,
 ):
@@ -202,7 +209,7 @@ async def test_run_transfer_hive_to_postgres(
     _, fill_with_data = prepare_hive
     fill_with_data(init_df)
     postgres, _ = prepare_postgres
-    init_df = init_df.where(expected_filter(init_df))
+    init_df = expected_filter(init_df, source_type)
 
     # Act
     result = await client.post(

--- a/tests/test_integration/test_run_transfer/test_mysql.py
+++ b/tests/test_integration/test_run_transfer/test_mysql.py
@@ -203,11 +203,17 @@ async def test_run_transfer_postgres_to_mysql_mixed_naming(
 
 
 @pytest.mark.parametrize(
-    "transformations, expected_filter",
+    "source_type, transformations, expected_filter",
     [
         (
+            "mysql",
             lf("dataframe_rows_filter_transformations"),
             lf("expected_dataframe_rows_filter"),
+        ),
+        (
+            "mysql",
+            lf("dataframe_columns_filter_transformations"),
+            lf("expected_dataframe_columns_filter"),
         ),
     ],
 )
@@ -218,6 +224,7 @@ async def test_run_transfer_mysql_to_postgres(
     prepare_postgres,
     init_df: DataFrame,
     mysql_to_postgres: Transfer,
+    source_type,
     transformations,
     expected_filter,
 ):
@@ -225,7 +232,7 @@ async def test_run_transfer_mysql_to_postgres(
     _, fill_with_data = prepare_mysql
     fill_with_data(init_df)
     postgres, _ = prepare_postgres
-    init_df = init_df.where(expected_filter(init_df))
+    init_df = expected_filter(init_df, source_type)
 
     # Act
     result = await client.post(

--- a/tests/test_integration/test_run_transfer/test_oracle.py
+++ b/tests/test_integration/test_run_transfer/test_oracle.py
@@ -182,11 +182,17 @@ async def test_run_transfer_postgres_to_oracle_mixed_naming(
 
 
 @pytest.mark.parametrize(
-    "transformations, expected_filter",
+    "source_type, transformations, expected_filter",
     [
         (
+            "oracle",
             lf("dataframe_rows_filter_transformations"),
             lf("expected_dataframe_rows_filter"),
+        ),
+        (
+            "oracle",
+            lf("dataframe_columns_filter_transformations"),
+            lf("expected_dataframe_columns_filter"),
         ),
     ],
 )
@@ -197,6 +203,7 @@ async def test_run_transfer_oracle_to_postgres(
     prepare_postgres,
     init_df: DataFrame,
     oracle_to_postgres: Transfer,
+    source_type,
     transformations,
     expected_filter,
 ):
@@ -204,7 +211,7 @@ async def test_run_transfer_oracle_to_postgres(
     _, fill_with_data = prepare_oracle
     fill_with_data(init_df)
     postgres, _ = prepare_postgres
-    init_df = init_df.where(expected_filter(init_df))
+    init_df = expected_filter(init_df, source_type)
 
     # Act
     result = await client.post(

--- a/tests/test_unit/test_transfers/test_create_transfer.py
+++ b/tests/test_unit/test_transfers/test_create_transfer.py
@@ -52,6 +52,25 @@ async def test_developer_plus_can_create_transfer(
                         },
                     ],
                 },
+                {
+                    "type": "dataframe_columns_filter",
+                    "filters": [
+                        {
+                            "type": "include",
+                            "field": "col1",
+                        },
+                        {
+                            "type": "rename",
+                            "field": "col2",
+                            "to": "new_col2",
+                        },
+                        {
+                            "type": "cast",
+                            "field": "col3",
+                            "as_type": "VARCHAR",
+                        },
+                    ],
+                },
             ],
             "queue_id": group_queue.id,
         },
@@ -447,12 +466,12 @@ async def test_superuser_can_create_transfer(
                             "location": ["body", "transformations", 0],
                             "message": (
                                 "Input tag 'some unknown transformation type' found using 'type' "
-                                "does not match any of the expected tags: 'dataframe_rows_filter'"
+                                "does not match any of the expected tags: 'dataframe_rows_filter', 'dataframe_columns_filter'"
                             ),
                             "code": "union_tag_invalid",
                             "context": {
                                 "discriminator": "'type'",
-                                "expected_tags": "'dataframe_rows_filter'",
+                                "expected_tags": "'dataframe_rows_filter', 'dataframe_columns_filter'",
                                 "tag": "some unknown transformation type",
                             },
                             "input": {
@@ -506,6 +525,47 @@ async def test_superuser_can_create_transfer(
                                 "type": "equals_today",
                                 "field": "col1",
                                 "value": "something",
+                            },
+                        },
+                    ],
+                },
+            },
+        ),
+        (
+            {
+                "transformations": [
+                    {
+                        "type": "dataframe_columns_filter",
+                        "filters": [
+                            {
+                                "type": "convert",
+                                "field": "col1",
+                                "value": "VARCHAR",
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                "error": {
+                    "code": "invalid_request",
+                    "message": "Invalid request",
+                    "details": [
+                        {
+                            "location": ["body", "transformations", 0, "dataframe_columns_filter", "filters", 0],
+                            "message": (
+                                "Input tag 'convert' found using 'type' does not match any of the expected tags: 'include', 'rename', 'cast'"
+                            ),
+                            "code": "union_tag_invalid",
+                            "context": {
+                                "discriminator": "'type'",
+                                "tag": "convert",
+                                "expected_tags": "'include', 'rename', 'cast'",
+                            },
+                            "input": {
+                                "type": "convert",
+                                "field": "col1",
+                                "value": "VARCHAR",
                             },
                         },
                     ],

--- a/tests/test_unit/test_transfers/test_file_transfers/test_update_transfer.py
+++ b/tests/test_unit/test_transfers/test_file_transfers/test_update_transfer.py
@@ -88,6 +88,15 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.server]
                         },
                     ],
                 },
+                {
+                    "type": "dataframe_columns_filter",
+                    "filters": [
+                        {
+                            "type": "include",
+                            "field": "col1",
+                        },
+                    ],
+                },
             ],
         },
     ],


### PR DESCRIPTION
## Change Summary

- Added a schema for `DataframeColumnsFilter` transformation:  
  ```json
  {
    "type": "dataframe_columns_filter",
    "filters": [
      {
        "type": "include",
        "field": "col1"
      },
      {
        "type": "rename",
        "field": "col2",
        "to": "new_col2"
      },
      {
        "type": "cast",
        "field": "col3",
        "as_type": "DATE"
      }
    ]
  }
  ```

- Supported filter types:
  - `include`
  - `rename`
  - `cast`

- Implemented logic in the worker to handle DataframeColumnsFilter transformations: if a filter is present, it is applied to DBReader(columns=['"col1"', '"col2" AS "new_col2"', 'CAST("col3" as DATE) AS "col3"']) for DBHandler types and df.selectExpr("...") for FileHandlers. Filters are converted into a single SQL-like condition using AND, e.g.,
    ```SQL
    "col1", "col2" AS "new_col2", CAST("col3" AS DATE) AS "col3"
    ```

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.