### PR TITLE
[DOP-22126] Add incremental strategy to API

### DIFF
--- a/docs/changelog/next_release/202.feature.rst
+++ b/docs/changelog/next_release/202.feature.rst
@@ -1,0 +1,1 @@
+Add `increment_by` field to `strategy_params`

--- a/syncmaster/schemas/v1/connection_types.py
+++ b/syncmaster/schemas/v1/connection_types.py
@@ -15,3 +15,21 @@ FTP_TYPE = Literal["ftp"]
 FTPS_TYPE = Literal["ftps"]
 WEBDAV_TYPE = Literal["webdav"]
 SAMBA_TYPE = Literal["samba"]
+
+CONNECTION_TYPES = [
+    "oracle",
+    "postgres",
+    "clickhouse",
+    "hive",
+    "mssql",
+    "mysql",
+    "s3",
+    "hdfs",
+    "sftp",
+    "ftp",
+    "ftps",
+    "webdav",
+    "samba",
+]
+FILE_CONNECTION_TYPES = ["s3", "hdfs", "sftp", "ftp", "ftps", "webdav", "samba"]
+DB_CONNECTION_TYPES = ["oracle", "postgres", "clickhouse", "hive", "mssql", "mysql"]

--- a/syncmaster/schemas/v1/transfers/strategy.py
+++ b/syncmaster/schemas/v1/transfers/strategy.py
@@ -13,3 +13,4 @@ class FullStrategy(BaseModel):
 
 class IncrementalStrategy(BaseModel):
     type: INCREMENTAL_TYPE
+    increment_by: str

--- a/syncmaster/server/api/v1/connections.py
+++ b/syncmaster/server/api/v1/connections.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2023-2024 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 from collections.abc import Sequence
-from typing import get_args
 
 from fastapi import APIRouter, Depends, Query, status
 from pydantic import TypeAdapter
@@ -17,16 +16,7 @@ from syncmaster.exceptions.connection import (
 )
 from syncmaster.exceptions.credentials import AuthDataNotFoundError
 from syncmaster.exceptions.group import GroupNotFoundError
-from syncmaster.schemas.v1.connection_types import (
-    CLICKHOUSE_TYPE,
-    HDFS_TYPE,
-    HIVE_TYPE,
-    MSSQL_TYPE,
-    MYSQL_TYPE,
-    ORACLE_TYPE,
-    POSTGRES_TYPE,
-    S3_TYPE,
-)
+from syncmaster.schemas.v1.connection_types import CONNECTION_TYPES
 from syncmaster.schemas.v1.connections.connection import (
     ConnectionCopySchema,
     ConnectionPageSchema,
@@ -40,8 +30,6 @@ from syncmaster.server.services.get_user import get_user
 from syncmaster.server.services.unit_of_work import UnitOfWork
 
 router = APIRouter(tags=["Connections"], responses=get_error_responses())
-
-CONNECTION_TYPES = ORACLE_TYPE, POSTGRES_TYPE, CLICKHOUSE_TYPE, HIVE_TYPE, MSSQL_TYPE, MYSQL_TYPE, S3_TYPE, HDFS_TYPE
 
 
 @router.get("/connections")
@@ -157,7 +145,7 @@ async def create_connection(
 
 @router.get("/connections/known_types", dependencies=[Depends(get_user(is_active=True))])
 async def read_connection_types() -> list[str]:
-    return [get_args(type_)[0] for type_ in CONNECTION_TYPES]
+    return CONNECTION_TYPES
 
 
 @router.get("/connections/{connection_id}")

--- a/tests/test_unit/test_connections/test_read_connection_types.py
+++ b/tests/test_unit/test_connections/test_read_connection_types.py
@@ -1,9 +1,7 @@
-from typing import get_args
-
 import pytest
 from httpx import AsyncClient
 
-from syncmaster.server.api.v1.connections import CONNECTION_TYPES
+from syncmaster.schemas.v1.connection_types import CONNECTION_TYPES
 from tests.mocks import MockUser
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.server]
@@ -31,4 +29,4 @@ async def test_groupless_user_can_read_connection_types(client: AsyncClient, sim
     )
     # Assert
     assert result.status_code == 200
-    assert set(result.json()) == {get_args(type)[0] for type in CONNECTION_TYPES}
+    assert set(result.json()) == set(CONNECTION_TYPES)

--- a/tests/test_unit/test_transfers/test_file_transfers/test_read_transfer.py
+++ b/tests/test_unit/test_transfers/test_file_transfers/test_read_transfer.py
@@ -104,6 +104,10 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.server]
             "target_params": {
                 "file_name_template": "{run_created_at}_{index}.{extension}",
             },
+            "strategy_params": {
+                "type": "incremental",
+                "increment_by": "modified_since",
+            },
         },
     ],
 )

--- a/tests/test_unit/test_transfers/test_update_transfer.py
+++ b/tests/test_unit/test_transfers/test_update_transfer.py
@@ -14,12 +14,20 @@ async def test_developer_plus_can_update_transfer(
 ):
     # Arrange
     user = group_transfer.owner_group.get_member_of_role(role_developer_plus)
+    updated_fields = {
+        "name": "New transfer name",
+        "is_scheduled": False,
+        "strategy_params": {
+            "type": "incremental",
+            "increment_by": "updated_at",
+        },
+    }
 
     # Act
     result = await client.patch(
         f"v1/transfers/{group_transfer.id}",
         headers={"Authorization": f"Bearer {user.token}"},
-        json={"name": "New transfer name", "is_scheduled": False},
+        json=updated_fields,
     )
 
     # Assert
@@ -27,15 +35,15 @@ async def test_developer_plus_can_update_transfer(
     assert result.json() == {
         "id": group_transfer.id,
         "group_id": group_transfer.group_id,
-        "name": "New transfer name",
+        "name": updated_fields["name"],
         "description": group_transfer.description,
         "schedule": group_transfer.schedule,
-        "is_scheduled": False,
+        "is_scheduled": updated_fields["is_scheduled"],
         "source_connection_id": group_transfer.source_connection_id,
         "target_connection_id": group_transfer.target_connection_id,
         "source_params": group_transfer.source_params,
         "target_params": group_transfer.target_params,
-        "strategy_params": group_transfer.strategy_params,
+        "strategy_params": updated_fields["strategy_params"],
         "transformations": group_transfer.transformations,
         "queue_id": group_transfer.transfer.queue_id,
     }


### PR DESCRIPTION
## Change Summary

Added the `increment_by` field to the `IncrementalStrategy` schema. Implemented validation to ensure that for file based sources `increment_by` can only be `modified_since`, while for database sources it can be any string representing a column name.

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.