### PR TITLE
[DOP-22132] Implement increment for transfers with DB source

### DIFF
--- a/docs/changelog/next_release/211.feature.rst
+++ b/docs/changelog/next_release/211.feature.rst
@@ -1,0 +1,1 @@
+Implement increment for transfers with database sources

--- a/syncmaster/worker/controller.py
+++ b/syncmaster/worker/controller.py
@@ -42,6 +42,7 @@ from syncmaster.dto.transfers import (
 )
 from syncmaster.dto.transfers_strategy import Strategy
 from syncmaster.exceptions.connection import ConnectionTypeNotRecognizedError
+from syncmaster.schemas.v1.connection_types import FILE_CONNECTION_TYPES
 from syncmaster.worker.handlers.base import Handler
 from syncmaster.worker.handlers.db.clickhouse import ClickhouseHandler
 from syncmaster.worker.handlers.db.hive import HiveHandler
@@ -242,11 +243,15 @@ class TransferController:
         ).force_create_namespace() as hwm_store:
 
             with IncrementalStrategy():
+                if self.source_handler.connection_dto.type in FILE_CONNECTION_TYPES:
+                    hwm_name_suffix = self.source_handler.transfer_dto.directory_path
+                else:
+                    hwm_name_suffix = self.source_handler.transfer_dto.table_name
                 hwm_name = "_".join(
                     [
                         str(self.source_handler.transfer_dto.id),
                         self.source_handler.connection_dto.type,
-                        self.source_handler.transfer_dto.directory_path,
+                        hwm_name_suffix,
                     ],
                 )
                 hwm = hwm_store.get_hwm(hwm_name)

--- a/tests/test_integration/test_run_transfer/connection_fixtures/__init__.py
+++ b/tests/test_integration/test_run_transfer/connection_fixtures/__init__.py
@@ -123,6 +123,7 @@ from tests.test_integration.test_run_transfer.connection_fixtures.strategy_fixtu
     full_strategy,
     incremental_strategy_by_file_modified_since,
     incremental_strategy_by_file_name,
+    incremental_strategy_by_number_column,
 )
 from tests.test_integration.test_run_transfer.connection_fixtures.webdav_fixtures import (
     prepare_webdav,

--- a/tests/test_integration/test_run_transfer/connection_fixtures/filters_fixtures.py
+++ b/tests/test_integration/test_run_transfer/connection_fixtures/filters_fixtures.py
@@ -50,13 +50,13 @@ def expected_dataframe_rows_filter():
 
 @pytest.fixture
 def dataframe_columns_filter_transformations(source_type: str):
-    string_types_per_source_type = {
-        "postgres": "VARCHAR(10)",
-        "oracle": "VARCHAR2(10)",
-        "clickhouse": "VARCHAR(10)",
+    string_type_per_source_type = {
+        "postgres": "VARCHAR(30)",
+        "oracle": "VARCHAR2(30)",
+        "clickhouse": "VARCHAR(30)",
         "mysql": "CHAR",
-        "mssql": "VARCHAR(10)",
-        "hive": "VARCHAR(10)",
+        "mssql": "VARCHAR(30)",
+        "hive": "VARCHAR(30)",
         "s3": "STRING",
         "hdfs": "STRING",
     }
@@ -84,7 +84,7 @@ def dataframe_columns_filter_transformations(source_type: str):
                 {
                     "type": "cast",
                     "field": "NUMBER",
-                    "as_type": string_types_per_source_type[source_type],
+                    "as_type": string_type_per_source_type[source_type],
                 },
                 {
                     "type": "include",

--- a/tests/test_integration/test_run_transfer/connection_fixtures/s3_fixtures.py
+++ b/tests/test_integration/test_run_transfer/connection_fixtures/s3_fixtures.py
@@ -82,7 +82,7 @@ def s3_file_connection(s3_server):
     return s3_connection
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def s3_file_connection_with_path(request, s3_file_connection):
     connection = s3_file_connection
     source = PurePosixPath("/data")
@@ -99,7 +99,7 @@ def s3_file_connection_with_path(request, s3_file_connection):
     return connection, source
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def s3_file_df_connection_with_path(s3_file_connection_with_path, s3_file_df_connection):
     _, root = s3_file_connection_with_path
     return s3_file_df_connection, root
@@ -123,7 +123,7 @@ def s3_file_df_connection(s3_file_connection, spark, s3_server):
     )
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def prepare_s3(
     resource_path: PosixPath,
     s3_file_connection: S3,

--- a/tests/test_integration/test_run_transfer/connection_fixtures/strategy_fixtures.py
+++ b/tests/test_integration/test_run_transfer/connection_fixtures/strategy_fixtures.py
@@ -22,3 +22,11 @@ def incremental_strategy_by_file_name():
         "type": "incremental",
         "increment_by": "file_name",
     }
+
+
+@pytest.fixture
+def incremental_strategy_by_number_column():
+    return {
+        "type": "incremental",
+        "increment_by": "NUMBER",
+    }

--- a/tests/test_integration/test_run_transfer/test_clickhouse.py
+++ b/tests/test_integration/test_run_transfer/test_clickhouse.py
@@ -9,10 +9,14 @@ from pyspark.sql import DataFrame
 from pytest_lazy_fixtures import lf
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from syncmaster.db.models import Connection, Group, Queue, Status, Transfer
+from syncmaster.db.models import Connection, Group, Queue, Transfer
 from tests.mocks import MockUser
 from tests.test_unit.utils import create_transfer
-from tests.utils import get_run_on_end
+from tests.utils import (
+    prepare_dataframes_for_comparison,
+    run_transfer_and_verify,
+    split_df,
+)
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.worker]
 
@@ -25,6 +29,7 @@ async def postgres_to_clickhouse(
     clickhouse_for_conftest: Clickhouse,
     clickhouse_connection: Connection,
     postgres_connection: Connection,
+    strategy: dict,
     transformations: list[dict],
 ):
     result = await create_transfer(
@@ -41,6 +46,7 @@ async def postgres_to_clickhouse(
             "type": "clickhouse",
             "table_name": f"{clickhouse_for_conftest.user}.target_table",
         },
+        strategy_params=strategy,
         transformations=transformations,
         queue_id=queue.id,
     )
@@ -57,6 +63,7 @@ async def clickhouse_to_postgres(
     clickhouse_for_conftest: Clickhouse,
     clickhouse_connection: Connection,
     postgres_connection: Connection,
+    strategy: dict,
     transformations: list[dict],
 ):
     result = await create_transfer(
@@ -73,6 +80,7 @@ async def clickhouse_to_postgres(
             "type": "postgres",
             "table_name": "public.target_table",
         },
+        strategy_params=strategy,
         transformations=transformations,
         queue_id=queue.id,
     )
@@ -82,21 +90,23 @@ async def clickhouse_to_postgres(
 
 
 @pytest.mark.parametrize(
-    "source_type, transformations, expected_filter",
+    "source_type, strategy, transformations, expected_filter",
     [
         (
-            "clickhouse",
+            "postgres",
+            lf("full_strategy"),
             lf("dataframe_rows_filter_transformations"),
             lf("expected_dataframe_rows_filter"),
         ),
         (
-            "clickhouse",
+            "postgres",
+            lf("full_strategy"),
             lf("dataframe_columns_filter_transformations"),
             lf("expected_dataframe_columns_filter"),
         ),
     ],
 )
-async def test_run_transfer_postgres_to_clickhouse(
+async def test_run_transfer_postgres_to_clickhouse_with_full_strategy(
     client: AsyncClient,
     group_owner: MockUser,
     prepare_postgres,
@@ -104,154 +114,148 @@ async def test_run_transfer_postgres_to_clickhouse(
     init_df: DataFrame,
     postgres_to_clickhouse: Transfer,
     source_type,
+    strategy,
     transformations,
     expected_filter,
 ):
-    # Arrange
     _, fill_with_data = prepare_postgres
     fill_with_data(init_df)
     clickhouse, _ = prepare_clickhouse
     init_df = expected_filter(init_df, source_type)
 
-    # Act
-    result = await client.post(
-        "v1/runs",
-        headers={"Authorization": f"Bearer {group_owner.token}"},
-        json={"transfer_id": postgres_to_clickhouse.id},
-    )
-    # Assert
-    assert result.status_code == 200
+    await run_transfer_and_verify(client, group_owner, postgres_to_clickhouse.id)
 
-    run_data = await get_run_on_end(
-        client=client,
-        run_id=result.json()["id"],
-        token=group_owner.token,
-    )
-    source_auth_data = run_data["transfer_dump"]["source_connection"]["auth_data"]
-    target_auth_data = run_data["transfer_dump"]["target_connection"]["auth_data"]
-
-    assert run_data["status"] == Status.FINISHED.value
-    assert source_auth_data["user"]
-    assert "password" not in source_auth_data
-    assert target_auth_data["user"]
-    assert "password" not in target_auth_data
     reader = DBReader(
         connection=clickhouse,
         table=f"{clickhouse.user}.target_table",
     )
     df = reader.run()
-    for field in init_df.schema:
-        df = df.withColumn(field.name, df[field.name].cast(field.dataType))
 
+    df, init_df = prepare_dataframes_for_comparison(df, init_df)
     assert df.sort("ID").collect() == init_df.sort("ID").collect()
 
 
-@pytest.mark.parametrize("transformations", [[]])
-async def test_run_transfer_postgres_to_clickhouse_mixed_naming(
+@pytest.mark.parametrize(
+    "strategy, transformations",
+    [
+        (
+            lf("full_strategy"),
+            [],
+        ),
+    ],
+)
+async def test_run_transfer_postgres_to_clickhouse_mixed_naming_with_full_strategy(
     client: AsyncClient,
     group_owner: MockUser,
     prepare_postgres,
     prepare_clickhouse,
     init_df_with_mixed_column_naming: DataFrame,
     postgres_to_clickhouse: Transfer,
+    strategy,
     transformations,
 ):
-    # Arrange
     _, fill_with_data = prepare_postgres
     fill_with_data(init_df_with_mixed_column_naming)
     clickhouse, _ = prepare_clickhouse
 
-    # Act
-    result = await client.post(
-        "v1/runs",
-        headers={"Authorization": f"Bearer {group_owner.token}"},
-        json={"transfer_id": postgres_to_clickhouse.id},
-    )
-    # Assert
-    assert result.status_code == 200
-
-    run_data = await get_run_on_end(
-        client=client,
-        run_id=result.json()["id"],
-        token=group_owner.token,
-    )
-    source_auth_data = run_data["transfer_dump"]["source_connection"]["auth_data"]
-    target_auth_data = run_data["transfer_dump"]["target_connection"]["auth_data"]
-
-    assert run_data["status"] == Status.FINISHED.value
-    assert source_auth_data["user"]
-    assert "password" not in source_auth_data
-    assert target_auth_data["user"]
-    assert "password" not in target_auth_data
+    await run_transfer_and_verify(client, group_owner, postgres_to_clickhouse.id)
 
     reader = DBReader(
         connection=clickhouse,
         table=f"{clickhouse.user}.target_table",
     )
     df = reader.run()
+
     assert df.columns != init_df_with_mixed_column_naming.columns
     assert df.columns == [column.lower() for column in init_df_with_mixed_column_naming.columns]
 
-    for field in init_df_with_mixed_column_naming.schema:
-        df = df.withColumn(field.name, df[field.name].cast(field.dataType))
-
+    df, init_df_with_mixed_column_naming = prepare_dataframes_for_comparison(df, init_df_with_mixed_column_naming)
     assert df.sort("ID").collect() == init_df_with_mixed_column_naming.sort("ID").collect()
 
 
 @pytest.mark.parametrize(
-    "source_type, transformations, expected_filter",
+    "strategy, transformations",
+    [
+        (
+            lf("incremental_strategy_by_number_column"),
+            [],
+        ),
+    ],
+)
+async def test_run_transfer_postgres_to_clickhouse_with_incremental_strategy(
+    client: AsyncClient,
+    group_owner: MockUser,
+    prepare_postgres,
+    prepare_clickhouse,
+    init_df: DataFrame,
+    postgres_to_clickhouse: Transfer,
+    strategy,
+    transformations,
+):
+    _, fill_with_data = prepare_postgres
+    clickhouse, _ = prepare_clickhouse
+
+    first_transfer_df, second_transfer_df = split_df(df=init_df, ratio=0.6, keep_sorted_by="number")
+    fill_with_data(first_transfer_df)
+    await run_transfer_and_verify(client, group_owner, postgres_to_clickhouse.id)
+
+    reader = DBReader(
+        connection=clickhouse,
+        table=f"{clickhouse.user}.target_table",
+    )
+    df = reader.run()
+
+    df, first_transfer_df = prepare_dataframes_for_comparison(df, first_transfer_df)
+    assert df.sort("ID").collect() == first_transfer_df.sort("ID").collect()
+
+    fill_with_data(second_transfer_df)
+    await run_transfer_and_verify(client, group_owner, postgres_to_clickhouse.id)
+
+    reader = DBReader(
+        connection=clickhouse,
+        table=f"{clickhouse.user}.target_table",
+    )
+    df_with_increment = reader.run()
+
+    df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df)
+    assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()
+
+
+@pytest.mark.parametrize(
+    "source_type, strategy, transformations, expected_filter",
     [
         (
             "clickhouse",
+            lf("full_strategy"),
             lf("dataframe_rows_filter_transformations"),
             lf("expected_dataframe_rows_filter"),
         ),
         (
             "clickhouse",
+            lf("full_strategy"),
             lf("dataframe_columns_filter_transformations"),
             lf("expected_dataframe_columns_filter"),
         ),
     ],
 )
-async def test_run_transfer_clickhouse_to_postgres(
+async def test_run_transfer_clickhouse_to_postgres_with_full_strategy(
     client: AsyncClient,
     group_owner: MockUser,
     prepare_clickhouse,
     prepare_postgres,
     init_df: DataFrame,
     source_type,
+    strategy,
     transformations,
     expected_filter,
     clickhouse_to_postgres: Transfer,
 ):
-    # Arrange
     _, fill_with_data = prepare_clickhouse
     fill_with_data(init_df)
     postgres, _ = prepare_postgres
     init_df = expected_filter(init_df, source_type)
 
-    # Act
-    result = await client.post(
-        "v1/runs",
-        headers={"Authorization": f"Bearer {group_owner.token}"},
-        json={"transfer_id": clickhouse_to_postgres.id},
-    )
-    # Assert
-    assert result.status_code == 200
-
-    run_data = await get_run_on_end(
-        client=client,
-        run_id=result.json()["id"],
-        token=group_owner.token,
-    )
-    source_auth_data = run_data["transfer_dump"]["source_connection"]["auth_data"]
-    target_auth_data = run_data["transfer_dump"]["target_connection"]["auth_data"]
-
-    assert run_data["status"] == Status.FINISHED.value
-    assert source_auth_data["user"]
-    assert "password" not in source_auth_data
-    assert target_auth_data["user"]
-    assert "password" not in target_auth_data
+    await run_transfer_and_verify(client, group_owner, clickhouse_to_postgres.id)
 
     reader = DBReader(
         connection=postgres,
@@ -259,49 +263,34 @@ async def test_run_transfer_clickhouse_to_postgres(
     )
     df = reader.run()
 
-    for field in init_df.schema:
-        df = df.withColumn(field.name, df[field.name].cast(field.dataType))
-
+    df, init_df = prepare_dataframes_for_comparison(df, init_df)
     assert df.sort("ID").collect() == init_df.sort("ID").collect()
 
 
-@pytest.mark.parametrize("transformations", [[]])
-async def test_run_transfer_clickhouse_to_postgres_mixed_naming(
+@pytest.mark.parametrize(
+    "strategy, transformations",
+    [
+        (
+            lf("full_strategy"),
+            [],
+        ),
+    ],
+)
+async def test_run_transfer_clickhouse_to_postgres_mixed_naming_with_full_strategy(
     client: AsyncClient,
     group_owner: MockUser,
     prepare_clickhouse,
     prepare_postgres,
     init_df_with_mixed_column_naming: DataFrame,
     clickhouse_to_postgres: Transfer,
+    strategy,
     transformations,
 ):
-    # Arrange
     _, fill_with_data = prepare_clickhouse
     fill_with_data(init_df_with_mixed_column_naming)
     postgres, _ = prepare_postgres
 
-    # Act
-    result = await client.post(
-        "v1/runs",
-        headers={"Authorization": f"Bearer {group_owner.token}"},
-        json={"transfer_id": clickhouse_to_postgres.id},
-    )
-    # Assert
-    assert result.status_code == 200
-
-    run_data = await get_run_on_end(
-        client=client,
-        run_id=result.json()["id"],
-        token=group_owner.token,
-    )
-    source_auth_data = run_data["transfer_dump"]["source_connection"]["auth_data"]
-    target_auth_data = run_data["transfer_dump"]["target_connection"]["auth_data"]
-
-    assert run_data["status"] == Status.FINISHED.value
-    assert source_auth_data["user"]
-    assert "password" not in source_auth_data
-    assert target_auth_data["user"]
-    assert "password" not in target_auth_data
+    await run_transfer_and_verify(client, group_owner, clickhouse_to_postgres.id)
 
     reader = DBReader(
         connection=postgres,
@@ -312,7 +301,53 @@ async def test_run_transfer_clickhouse_to_postgres_mixed_naming(
     assert df.columns != init_df_with_mixed_column_naming.columns
     assert df.columns == [column.lower() for column in init_df_with_mixed_column_naming.columns]
 
-    for field in init_df_with_mixed_column_naming.schema:
-        df = df.withColumn(field.name, df[field.name].cast(field.dataType))
-
+    df, init_df_with_mixed_column_naming = prepare_dataframes_for_comparison(df, init_df_with_mixed_column_naming)
     assert df.sort("ID").collect() == init_df_with_mixed_column_naming.sort("ID").collect()
+
+
+@pytest.mark.parametrize(
+    "strategy, transformations",
+    [
+        (
+            lf("incremental_strategy_by_number_column"),
+            [],
+        ),
+    ],
+)
+async def test_run_transfer_clickhouse_to_postgres_with_incremental_strategy(
+    client: AsyncClient,
+    group_owner: MockUser,
+    prepare_clickhouse,
+    prepare_postgres,
+    init_df: DataFrame,
+    strategy,
+    transformations,
+    clickhouse_to_postgres: Transfer,
+):
+    _, fill_with_data = prepare_clickhouse
+    postgres, _ = prepare_postgres
+
+    first_transfer_df, second_transfer_df = split_df(df=init_df, ratio=0.6, keep_sorted_by="number")
+    fill_with_data(first_transfer_df)
+    await run_transfer_and_verify(client, group_owner, clickhouse_to_postgres.id)
+
+    reader = DBReader(
+        connection=postgres,
+        table="public.target_table",
+    )
+    df = reader.run()
+
+    df, first_transfer_df = prepare_dataframes_for_comparison(df, first_transfer_df)
+    assert df.sort("ID").collect() == first_transfer_df.sort("ID").collect()
+
+    fill_with_data(second_transfer_df)
+    await run_transfer_and_verify(client, group_owner, clickhouse_to_postgres.id)
+
+    reader = DBReader(
+        connection=postgres,
+        table="public.target_table",
+    )
+    df_with_increment = reader.run()
+
+    df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df)
+    assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()

--- a/tests/test_integration/test_run_transfer/test_clickhouse.py
+++ b/tests/test_integration/test_run_transfer/test_clickhouse.py
@@ -211,12 +211,7 @@ async def test_run_transfer_postgres_to_clickhouse_with_incremental_strategy(
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, postgres_to_clickhouse.id)
 
-    reader = DBReader(
-        connection=clickhouse,
-        table=f"{clickhouse.user}.target_table",
-    )
     df_with_increment = reader.run()
-
     df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df)
     assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()
 
@@ -343,11 +338,6 @@ async def test_run_transfer_clickhouse_to_postgres_with_incremental_strategy(
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, clickhouse_to_postgres.id)
 
-    reader = DBReader(
-        connection=postgres,
-        table="public.target_table",
-    )
     df_with_increment = reader.run()
-
     df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df)
     assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()

--- a/tests/test_integration/test_run_transfer/test_clickhouse.py
+++ b/tests/test_integration/test_run_transfer/test_clickhouse.py
@@ -13,7 +13,7 @@ from syncmaster.db.models import Connection, Group, Queue, Transfer
 from tests.mocks import MockUser
 from tests.test_unit.utils import create_transfer
 from tests.utils import (
-    prepare_dataframes_for_comparison,
+    cast_dataframe_types,
     run_transfer_and_verify,
     split_df,
 )
@@ -131,7 +131,7 @@ async def test_run_transfer_postgres_to_clickhouse_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(df, init_df)
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("ID").collect() == init_df.sort("ID").collect()
 
 
@@ -169,7 +169,7 @@ async def test_run_transfer_postgres_to_clickhouse_mixed_naming_with_full_strate
     assert df.columns != init_df_with_mixed_column_naming.columns
     assert df.columns == [column.lower() for column in init_df_with_mixed_column_naming.columns]
 
-    df, init_df_with_mixed_column_naming = prepare_dataframes_for_comparison(df, init_df_with_mixed_column_naming)
+    df, init_df_with_mixed_column_naming = cast_dataframe_types(df, init_df_with_mixed_column_naming)
     assert df.sort("ID").collect() == init_df_with_mixed_column_naming.sort("ID").collect()
 
 
@@ -205,14 +205,14 @@ async def test_run_transfer_postgres_to_clickhouse_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, first_transfer_df = prepare_dataframes_for_comparison(df, first_transfer_df)
+    df, first_transfer_df = cast_dataframe_types(df, first_transfer_df)
     assert df.sort("ID").collect() == first_transfer_df.sort("ID").collect()
 
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, postgres_to_clickhouse.id)
 
     df_with_increment = reader.run()
-    df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df)
+    df_with_increment, init_df = cast_dataframe_types(df_with_increment, init_df)
     assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()
 
 
@@ -258,7 +258,7 @@ async def test_run_transfer_clickhouse_to_postgres_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(df, init_df)
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("ID").collect() == init_df.sort("ID").collect()
 
 
@@ -296,7 +296,7 @@ async def test_run_transfer_clickhouse_to_postgres_mixed_naming_with_full_strate
     assert df.columns != init_df_with_mixed_column_naming.columns
     assert df.columns == [column.lower() for column in init_df_with_mixed_column_naming.columns]
 
-    df, init_df_with_mixed_column_naming = prepare_dataframes_for_comparison(df, init_df_with_mixed_column_naming)
+    df, init_df_with_mixed_column_naming = cast_dataframe_types(df, init_df_with_mixed_column_naming)
     assert df.sort("ID").collect() == init_df_with_mixed_column_naming.sort("ID").collect()
 
 
@@ -332,12 +332,12 @@ async def test_run_transfer_clickhouse_to_postgres_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, first_transfer_df = prepare_dataframes_for_comparison(df, first_transfer_df)
+    df, first_transfer_df = cast_dataframe_types(df, first_transfer_df)
     assert df.sort("ID").collect() == first_transfer_df.sort("ID").collect()
 
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, clickhouse_to_postgres.id)
 
     df_with_increment = reader.run()
-    df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df)
+    df_with_increment, init_df = cast_dataframe_types(df_with_increment, init_df)
     assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()

--- a/tests/test_integration/test_run_transfer/test_ftp.py
+++ b/tests/test_integration/test_run_transfer/test_ftp.py
@@ -9,19 +9,19 @@ from onetl.connection import FTP, SparkLocalFS
 from onetl.db import DBReader
 from onetl.file import FileDFReader, FileDownloader
 from pyspark.sql import DataFrame
-from pyspark.sql.functions import col, date_format, to_timestamp
 from pytest_lazy_fixtures import lf
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from syncmaster.db.models import Connection, Group, Queue, Status
+from syncmaster.db.models import Connection, Group, Queue
 from syncmaster.db.models.transfer import Transfer
 from tests.mocks import MockUser
 from tests.test_unit.utils import create_transfer
 from tests.utils import (
     add_increment_to_files_and_upload,
-    get_run_on_end,
     prepare_dataframes_for_comparison,
     run_transfer_and_verify,
+    split_df,
+    verify_file_name_template,
 )
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.worker]
@@ -81,6 +81,7 @@ async def postgres_to_ftp(
     postgres_connection: Connection,
     target_file_format,
     file_format_flavor: str,
+    strategy: dict,
 ):
     format_name, file_format = target_file_format
     result = await create_transfer(
@@ -103,6 +104,7 @@ async def postgres_to_ftp(
             "file_name_template": "{run_created_at}-{index}.{extension}",
             "options": {},
         },
+        strategy_params=strategy,
         queue_id=queue.id,
     )
     yield result
@@ -179,7 +181,12 @@ async def test_run_transfer_ftp_to_postgres_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(df, init_df, file_format)
+    df, init_df = prepare_dataframes_for_comparison(
+        df,
+        init_df,
+        file_format=file_format,
+        transfer_direction="file_to_db",
+    )
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
 
@@ -218,9 +225,13 @@ async def test_run_transfer_ftp_to_postgres_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(df, init_df, file_format)
+    df, init_df = prepare_dataframes_for_comparison(
+        df,
+        init_df,
+        file_format=file_format,
+        transfer_direction="file_to_db",
+    )
     assert df.sort("id").collect() == init_df.sort("id").collect()
-    df_count = df.count()
 
     add_increment_to_files_and_upload(
         file_connection=ftp_file_connection,
@@ -236,58 +247,69 @@ async def test_run_transfer_ftp_to_postgres_with_incremental_strategy(
     )
     df_with_increment = reader.run()
 
-    df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df, file_format)
-    assert df_with_increment.count() > df_count
+    df_with_increment, init_df = prepare_dataframes_for_comparison(
+        df_with_increment,
+        init_df,
+        file_format=file_format,
+        transfer_direction="file_to_db",
+    )
     assert df_with_increment.sort("id").collect() == init_df.union(init_df).sort("id").collect()
 
 
 @pytest.mark.parametrize(
-    "target_file_format, file_format_flavor, expected_extension",
+    "target_file_format, file_format_flavor, expected_extension, strategy",
     [
         pytest.param(
             ("csv", {"compression": "lz4"}),
             "with_compression",
             "csv.lz4",
+            lf("full_strategy"),
             id="csv",
         ),
         pytest.param(
             ("jsonline", {}),
             "without_compression",
             "jsonl",
+            lf("full_strategy"),
             id="jsonline",
         ),
         pytest.param(
             ("excel", {}),
             "with_header",
             "xlsx",
+            lf("full_strategy"),
             id="excel",
         ),
         pytest.param(
             ("orc", {"compression": "snappy"}),
             "with_compression",
             "snappy.orc",
+            lf("full_strategy"),
             id="orc",
         ),
         pytest.param(
             ("parquet", {"compression": "lz4"}),
             "with_compression",
             "lz4hadoop.parquet",
+            lf("full_strategy"),
             id="parquet",
         ),
         pytest.param(
             ("xml", {"compression": "snappy"}),
             "with_compression",
             "xml.snappy",
+            lf("full_strategy"),
             id="xml",
         ),
     ],
     indirect=["target_file_format", "file_format_flavor"],
 )
-async def test_run_transfer_postgres_to_ftp(
+async def test_run_transfer_postgres_to_ftp_with_full_strategy(
     group_owner: MockUser,
     init_df: DataFrame,
     client: AsyncClient,
     prepare_postgres,
+    ftp_file_connection_with_path,
     ftp_file_connection: FTP,
     ftp_file_df_connection: SparkLocalFS,
     postgres_to_ftp: Transfer,
@@ -295,35 +317,13 @@ async def test_run_transfer_postgres_to_ftp(
     file_format_flavor: str,
     tmp_path: Path,
     expected_extension: str,
+    strategy: dict,
 ):
     format_name, format = target_file_format
-
-    # Arrange
     _, fill_with_data = prepare_postgres
     fill_with_data(init_df)
 
-    # Act
-    result = await client.post(
-        "v1/runs",
-        headers={"Authorization": f"Bearer {group_owner.token}"},
-        json={"transfer_id": postgres_to_ftp.id},
-    )
-    # Assert
-    assert result.status_code == 200
-
-    run_data = await get_run_on_end(
-        client=client,
-        run_id=result.json()["id"],
-        token=group_owner.token,
-    )
-    source_auth_data = run_data["transfer_dump"]["source_connection"]["auth_data"]
-    target_auth_data = run_data["transfer_dump"]["target_connection"]["auth_data"]
-
-    assert run_data["status"] == Status.FINISHED.value
-    assert source_auth_data["user"]
-    assert "password" not in source_auth_data
-    assert target_auth_data["user"]
-    assert "password" not in target_auth_data
+    await run_transfer_and_verify(client, group_owner, postgres_to_ftp.id)
 
     downloader = FileDownloader(
         connection=ftp_file_connection,
@@ -332,11 +332,7 @@ async def test_run_transfer_postgres_to_ftp(
     )
     downloader.run()
 
-    files = os.listdir(tmp_path)
-    for file_name in files:
-        run_created_at, index_and_extension = file_name.split("-")
-        assert len(run_created_at.split("_")) == 6, f"Got wrong {run_created_at=}"
-        assert index_and_extension.split(".", 1)[1] == expected_extension
+    verify_file_name_template(os.listdir(tmp_path), expected_extension)
 
     reader = FileDFReader(
         connection=ftp_file_df_connection,
@@ -346,14 +342,100 @@ async def test_run_transfer_postgres_to_ftp(
     )
     df = reader.run()
 
-    # as Excel does not support datetime values with precision greater than milliseconds
-    if format_name == "excel":
-        init_df = init_df.withColumn(
-            "REGISTERED_AT",
-            to_timestamp(date_format(col("REGISTERED_AT"), "yyyy-MM-dd HH:mm:ss.SSS")),
-        )
-
-    for field in init_df.schema:
-        df = df.withColumn(field.name, df[field.name].cast(field.dataType))
-
+    df, init_df = prepare_dataframes_for_comparison(
+        df,
+        init_df,
+        file_format=format_name,
+        transfer_direction="db_to_file",
+    )
     assert df.sort("id").collect() == init_df.sort("id").collect()
+
+
+@pytest.mark.parametrize(
+    "target_file_format, file_format_flavor, expected_extension, strategy",
+    [
+        pytest.param(
+            ("csv", {"compression": "lz4"}),
+            "with_compression",
+            "csv.lz4",
+            lf("incremental_strategy_by_number_column"),
+            id="csv",
+        ),
+    ],
+    indirect=["target_file_format", "file_format_flavor"],
+)
+async def test_run_transfer_postgres_to_ftp_with_incremental_strategy(
+    group_owner: MockUser,
+    init_df: DataFrame,
+    client: AsyncClient,
+    prepare_postgres,
+    ftp_file_connection_with_path,
+    ftp_file_connection: FTP,
+    ftp_file_df_connection: SparkLocalFS,
+    postgres_to_ftp: Transfer,
+    target_file_format,
+    file_format_flavor: str,
+    tmp_path: Path,
+    expected_extension: str,
+    strategy: dict,
+):
+    format_name, format = target_file_format
+    _, fill_with_data = prepare_postgres
+
+    first_transfer_df, second_transfer_df = split_df(df=init_df, ratio=0.6, keep_sorted_by="number")
+    fill_with_data(first_transfer_df)
+
+    await run_transfer_and_verify(client, group_owner, postgres_to_ftp.id)
+
+    downloader = FileDownloader(
+        connection=ftp_file_connection,
+        source_path=f"/target/{format_name}/{file_format_flavor}",
+        local_path=tmp_path,
+    )
+    downloader.run()
+
+    verify_file_name_template(os.listdir(tmp_path), expected_extension)
+
+    reader = FileDFReader(
+        connection=ftp_file_df_connection,
+        format=format,
+        source_path=tmp_path,
+        df_schema=init_df.schema,
+    )
+    df = reader.run()
+
+    df, first_transfer_df = prepare_dataframes_for_comparison(
+        df,
+        first_transfer_df,
+        file_format=format_name,
+        transfer_direction="db_to_file",
+    )
+    assert df.sort("id").collect() == first_transfer_df.sort("id").collect()
+
+    fill_with_data(second_transfer_df)
+    await run_transfer_and_verify(client, group_owner, postgres_to_ftp.id)
+
+    downloader = FileDownloader(
+        connection=ftp_file_connection,
+        source_path=f"/target/{format_name}/{file_format_flavor}",
+        local_path=tmp_path,
+    )
+    downloader.run()
+
+    verify_file_name_template(os.listdir(tmp_path), expected_extension)
+
+    reader = FileDFReader(
+        connection=ftp_file_df_connection,
+        format=format,
+        source_path=tmp_path,
+        df_schema=init_df.schema,
+    )
+    df_with_increment = reader.run()
+
+    df_with_increment, second_transfer_df = prepare_dataframes_for_comparison(
+        df_with_increment,
+        second_transfer_df,
+        file_format=format_name,
+        transfer_direction="db_to_file",
+    )
+    assert df_with_increment.sort("id").collect() == init_df.sort("id").collect()

--- a/tests/test_integration/test_run_transfer/test_ftp.py
+++ b/tests/test_integration/test_run_transfer/test_ftp.py
@@ -241,12 +241,7 @@ async def test_run_transfer_ftp_to_postgres_with_incremental_strategy(
 
     await run_transfer_and_verify(client, group_owner, ftp_to_postgres.id)
 
-    reader = DBReader(
-        connection=postgres,
-        table="public.target_table",
-    )
     df_with_increment = reader.run()
-
     df_with_increment, init_df = prepare_dataframes_for_comparison(
         df_with_increment,
         init_df,
@@ -415,23 +410,10 @@ async def test_run_transfer_postgres_to_ftp_with_incremental_strategy(
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, postgres_to_ftp.id)
 
-    downloader = FileDownloader(
-        connection=ftp_file_connection,
-        source_path=f"/target/{format_name}/{file_format_flavor}",
-        local_path=tmp_path,
-    )
     downloader.run()
-
     verify_file_name_template(os.listdir(tmp_path), expected_extension)
 
-    reader = FileDFReader(
-        connection=ftp_file_df_connection,
-        format=format,
-        source_path=tmp_path,
-        df_schema=init_df.schema,
-    )
     df_with_increment = reader.run()
-
     df_with_increment, second_transfer_df = prepare_dataframes_for_comparison(
         df_with_increment,
         second_transfer_df,

--- a/tests/test_integration/test_run_transfer/test_ftp.py
+++ b/tests/test_integration/test_run_transfer/test_ftp.py
@@ -18,9 +18,10 @@ from tests.mocks import MockUser
 from tests.test_unit.utils import create_transfer
 from tests.utils import (
     add_increment_to_files_and_upload,
-    prepare_dataframes_for_comparison,
+    cast_dataframe_types,
     run_transfer_and_verify,
     split_df,
+    truncate_datetime_to_seconds,
     verify_file_name_template,
 )
 
@@ -181,12 +182,10 @@ async def test_run_transfer_ftp_to_postgres_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(
-        df,
-        init_df,
-        file_format=file_format,
-        transfer_direction="file_to_db",
-    )
+    if file_format == "excel":
+        df, init_df = truncate_datetime_to_seconds(df, init_df, transfer_direction="file_to_db")
+
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
 
@@ -225,12 +224,7 @@ async def test_run_transfer_ftp_to_postgres_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(
-        df,
-        init_df,
-        file_format=file_format,
-        transfer_direction="file_to_db",
-    )
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
     add_increment_to_files_and_upload(
@@ -242,12 +236,7 @@ async def test_run_transfer_ftp_to_postgres_with_incremental_strategy(
     await run_transfer_and_verify(client, group_owner, ftp_to_postgres.id)
 
     df_with_increment = reader.run()
-    df_with_increment, init_df = prepare_dataframes_for_comparison(
-        df_with_increment,
-        init_df,
-        file_format=file_format,
-        transfer_direction="file_to_db",
-    )
+    df_with_increment, init_df = cast_dataframe_types(df_with_increment, init_df)
     assert df_with_increment.sort("id").collect() == init_df.union(init_df).sort("id").collect()
 
 
@@ -337,12 +326,10 @@ async def test_run_transfer_postgres_to_ftp_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(
-        df,
-        init_df,
-        file_format=format_name,
-        transfer_direction="db_to_file",
-    )
+    if format_name == "excel":
+        df, init_df = truncate_datetime_to_seconds(df, init_df, transfer_direction="db_to_file")
+
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
 
@@ -399,12 +386,7 @@ async def test_run_transfer_postgres_to_ftp_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, first_transfer_df = prepare_dataframes_for_comparison(
-        df,
-        first_transfer_df,
-        file_format=format_name,
-        transfer_direction="db_to_file",
-    )
+    df, first_transfer_df = cast_dataframe_types(df, first_transfer_df)
     assert df.sort("id").collect() == first_transfer_df.sort("id").collect()
 
     fill_with_data(second_transfer_df)
@@ -414,10 +396,5 @@ async def test_run_transfer_postgres_to_ftp_with_incremental_strategy(
     verify_file_name_template(os.listdir(tmp_path), expected_extension)
 
     df_with_increment = reader.run()
-    df_with_increment, second_transfer_df = prepare_dataframes_for_comparison(
-        df_with_increment,
-        second_transfer_df,
-        file_format=format_name,
-        transfer_direction="db_to_file",
-    )
+    df_with_increment, second_transfer_df = cast_dataframe_types(df_with_increment, second_transfer_df)
     assert df_with_increment.sort("id").collect() == init_df.sort("id").collect()

--- a/tests/test_integration/test_run_transfer/test_ftps.py
+++ b/tests/test_integration/test_run_transfer/test_ftps.py
@@ -205,12 +205,7 @@ async def test_run_transfer_ftps_to_postgres_with_incremental_strategy(
 
     await run_transfer_and_verify(client, group_owner, ftps_to_postgres.id)
 
-    reader = DBReader(
-        connection=postgres,
-        table="public.target_table",
-    )
     df_with_increment = reader.run()
-
     df_with_increment, init_df = prepare_dataframes_for_comparison(
         df_with_increment,
         init_df,
@@ -344,23 +339,10 @@ async def test_run_transfer_postgres_to_ftps_with_incremental_strategy(
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, postgres_to_ftps.id)
 
-    downloader = FileDownloader(
-        connection=ftps_file_connection,
-        source_path=f"/target/{format_name}/{file_format_flavor}",
-        local_path=tmp_path,
-    )
     downloader.run()
-
     verify_file_name_template(os.listdir(tmp_path), expected_extension)
 
-    reader = FileDFReader(
-        connection=ftps_file_df_connection,
-        format=format,
-        source_path=tmp_path,
-        df_schema=init_df.schema,
-    )
     df_with_increment = reader.run()
-
     df_with_increment, second_transfer_df = prepare_dataframes_for_comparison(
         df_with_increment,
         second_transfer_df,

--- a/tests/test_integration/test_run_transfer/test_ftps.py
+++ b/tests/test_integration/test_run_transfer/test_ftps.py
@@ -12,15 +12,16 @@ from pyspark.sql import DataFrame
 from pytest_lazy_fixtures import lf
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from syncmaster.db.models import Connection, Group, Queue, Status
+from syncmaster.db.models import Connection, Group, Queue
 from syncmaster.db.models.transfer import Transfer
 from tests.mocks import MockUser
 from tests.test_unit.utils import create_transfer
 from tests.utils import (
     add_increment_to_files_and_upload,
-    get_run_on_end,
     prepare_dataframes_for_comparison,
     run_transfer_and_verify,
+    split_df,
+    verify_file_name_template,
 )
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.worker]
@@ -80,6 +81,7 @@ async def postgres_to_ftps(
     postgres_connection: Connection,
     target_file_format,
     file_format_flavor: str,
+    strategy: dict,
 ):
     format_name, file_format = target_file_format
     result = await create_transfer(
@@ -102,6 +104,7 @@ async def postgres_to_ftps(
             "file_name_template": "{run_created_at}-{index}.{extension}",
             "options": {},
         },
+        strategy_params=strategy,
         queue_id=queue.id,
     )
     yield result
@@ -142,7 +145,12 @@ async def test_run_transfer_ftps_to_postgres_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(df, init_df, file_format)
+    df, init_df = prepare_dataframes_for_comparison(
+        df,
+        init_df,
+        file_format=file_format,
+        transfer_direction="file_to_db",
+    )
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
 
@@ -158,7 +166,7 @@ async def test_run_transfer_ftps_to_postgres_with_full_strategy(
     ],
     indirect=["source_file_format", "file_format_flavor"],
 )
-async def test_run_transfer_ftp_to_postgres_with_incremental_strategy(
+async def test_run_transfer_ftps_to_postgres_with_incremental_strategy(
     prepare_postgres,
     group_owner: MockUser,
     init_df: DataFrame,
@@ -181,9 +189,13 @@ async def test_run_transfer_ftp_to_postgres_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(df, init_df, file_format)
+    df, init_df = prepare_dataframes_for_comparison(
+        df,
+        init_df,
+        file_format=file_format,
+        transfer_direction="file_to_db",
+    )
     assert df.sort("id").collect() == init_df.sort("id").collect()
-    df_count = df.count()
 
     add_increment_to_files_and_upload(
         file_connection=ftps_file_connection,
@@ -199,28 +211,34 @@ async def test_run_transfer_ftp_to_postgres_with_incremental_strategy(
     )
     df_with_increment = reader.run()
 
-    df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df, file_format)
-    assert df_with_increment.count() > df_count
+    df_with_increment, init_df = prepare_dataframes_for_comparison(
+        df_with_increment,
+        init_df,
+        file_format=file_format,
+        transfer_direction="file_to_db",
+    )
     assert df_with_increment.sort("id").collect() == init_df.union(init_df).sort("id").collect()
 
 
 @pytest.mark.parametrize(
-    "target_file_format, file_format_flavor, expected_extension",
+    "target_file_format, file_format_flavor, expected_extension, strategy",
     [
         pytest.param(
             ("csv", {"compression": "lz4"}),
             "with_compression",
             "csv.lz4",
+            lf("full_strategy"),
             id="csv",
         ),
     ],
     indirect=["target_file_format", "file_format_flavor"],
 )
-async def test_run_transfer_postgres_to_ftps(
+async def test_run_transfer_postgres_to_ftps_with_full_strategy(
     group_owner: MockUser,
     init_df: DataFrame,
     client: AsyncClient,
     prepare_postgres,
+    ftps_file_connection_with_path,
     ftps_file_connection: FTPS,
     ftps_file_df_connection: SparkLocalFS,
     postgres_to_ftps: Transfer,
@@ -228,35 +246,13 @@ async def test_run_transfer_postgres_to_ftps(
     file_format_flavor: str,
     tmp_path: Path,
     expected_extension: str,
+    strategy: dict,
 ):
     format_name, format = target_file_format
-
-    # Arrange
     _, fill_with_data = prepare_postgres
     fill_with_data(init_df)
 
-    # Act
-    result = await client.post(
-        "v1/runs",
-        headers={"Authorization": f"Bearer {group_owner.token}"},
-        json={"transfer_id": postgres_to_ftps.id},
-    )
-    # Assert
-    assert result.status_code == 200
-
-    run_data = await get_run_on_end(
-        client=client,
-        run_id=result.json()["id"],
-        token=group_owner.token,
-    )
-    source_auth_data = run_data["transfer_dump"]["source_connection"]["auth_data"]
-    target_auth_data = run_data["transfer_dump"]["target_connection"]["auth_data"]
-
-    assert run_data["status"] == Status.FINISHED.value
-    assert source_auth_data["user"]
-    assert "password" not in source_auth_data
-    assert target_auth_data["user"]
-    assert "password" not in target_auth_data
+    await run_transfer_and_verify(client, group_owner, postgres_to_ftps.id)
 
     downloader = FileDownloader(
         connection=ftps_file_connection,
@@ -265,11 +261,7 @@ async def test_run_transfer_postgres_to_ftps(
     )
     downloader.run()
 
-    files = os.listdir(tmp_path)
-    for file_name in files:
-        run_created_at, index_and_extension = file_name.split("-")
-        assert len(run_created_at.split("_")) == 6, f"Got wrong {run_created_at=}"
-        assert index_and_extension.split(".", 1)[1] == expected_extension
+    verify_file_name_template(os.listdir(tmp_path), expected_extension)
 
     reader = FileDFReader(
         connection=ftps_file_df_connection,
@@ -279,7 +271,100 @@ async def test_run_transfer_postgres_to_ftps(
     )
     df = reader.run()
 
-    for field in init_df.schema:
-        df = df.withColumn(field.name, df[field.name].cast(field.dataType))
-
+    df, init_df = prepare_dataframes_for_comparison(
+        df,
+        init_df,
+        file_format=format_name,
+        transfer_direction="db_to_file",
+    )
     assert df.sort("id").collect() == init_df.sort("id").collect()
+
+
+@pytest.mark.parametrize(
+    "target_file_format, file_format_flavor, expected_extension, strategy",
+    [
+        pytest.param(
+            ("csv", {"compression": "lz4"}),
+            "with_compression",
+            "csv.lz4",
+            lf("incremental_strategy_by_number_column"),
+            id="csv",
+        ),
+    ],
+    indirect=["target_file_format", "file_format_flavor"],
+)
+async def test_run_transfer_postgres_to_ftps_with_incremental_strategy(
+    group_owner: MockUser,
+    init_df: DataFrame,
+    client: AsyncClient,
+    prepare_postgres,
+    ftps_file_connection_with_path,
+    ftps_file_connection: FTPS,
+    ftps_file_df_connection: SparkLocalFS,
+    postgres_to_ftps: Transfer,
+    target_file_format,
+    file_format_flavor: str,
+    tmp_path: Path,
+    expected_extension: str,
+    strategy: dict,
+):
+    format_name, format = target_file_format
+    _, fill_with_data = prepare_postgres
+
+    first_transfer_df, second_transfer_df = split_df(df=init_df, ratio=0.6, keep_sorted_by="number")
+    fill_with_data(first_transfer_df)
+
+    await run_transfer_and_verify(client, group_owner, postgres_to_ftps.id)
+
+    downloader = FileDownloader(
+        connection=ftps_file_connection,
+        source_path=f"/target/{format_name}/{file_format_flavor}",
+        local_path=tmp_path,
+    )
+    downloader.run()
+
+    verify_file_name_template(os.listdir(tmp_path), expected_extension)
+
+    reader = FileDFReader(
+        connection=ftps_file_df_connection,
+        format=format,
+        source_path=tmp_path,
+        df_schema=init_df.schema,
+    )
+    df = reader.run()
+
+    df, first_transfer_df = prepare_dataframes_for_comparison(
+        df,
+        first_transfer_df,
+        file_format=format_name,
+        transfer_direction="db_to_file",
+    )
+    assert df.sort("id").collect() == first_transfer_df.sort("id").collect()
+
+    fill_with_data(second_transfer_df)
+    await run_transfer_and_verify(client, group_owner, postgres_to_ftps.id)
+
+    downloader = FileDownloader(
+        connection=ftps_file_connection,
+        source_path=f"/target/{format_name}/{file_format_flavor}",
+        local_path=tmp_path,
+    )
+    downloader.run()
+
+    verify_file_name_template(os.listdir(tmp_path), expected_extension)
+
+    reader = FileDFReader(
+        connection=ftps_file_df_connection,
+        format=format,
+        source_path=tmp_path,
+        df_schema=init_df.schema,
+    )
+    df_with_increment = reader.run()
+
+    df_with_increment, second_transfer_df = prepare_dataframes_for_comparison(
+        df_with_increment,
+        second_transfer_df,
+        file_format=format_name,
+        transfer_direction="db_to_file",
+    )
+    assert df_with_increment.sort("id").collect() == init_df.sort("id").collect()

--- a/tests/test_integration/test_run_transfer/test_ftps.py
+++ b/tests/test_integration/test_run_transfer/test_ftps.py
@@ -18,7 +18,7 @@ from tests.mocks import MockUser
 from tests.test_unit.utils import create_transfer
 from tests.utils import (
     add_increment_to_files_and_upload,
-    prepare_dataframes_for_comparison,
+    cast_dataframe_types,
     run_transfer_and_verify,
     split_df,
     verify_file_name_template,
@@ -145,12 +145,7 @@ async def test_run_transfer_ftps_to_postgres_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(
-        df,
-        init_df,
-        file_format=file_format,
-        transfer_direction="file_to_db",
-    )
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
 
@@ -189,12 +184,7 @@ async def test_run_transfer_ftps_to_postgres_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(
-        df,
-        init_df,
-        file_format=file_format,
-        transfer_direction="file_to_db",
-    )
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
     add_increment_to_files_and_upload(
@@ -206,12 +196,7 @@ async def test_run_transfer_ftps_to_postgres_with_incremental_strategy(
     await run_transfer_and_verify(client, group_owner, ftps_to_postgres.id)
 
     df_with_increment = reader.run()
-    df_with_increment, init_df = prepare_dataframes_for_comparison(
-        df_with_increment,
-        init_df,
-        file_format=file_format,
-        transfer_direction="file_to_db",
-    )
+    df_with_increment, init_df = cast_dataframe_types(df_with_increment, init_df)
     assert df_with_increment.sort("id").collect() == init_df.union(init_df).sort("id").collect()
 
 
@@ -266,12 +251,7 @@ async def test_run_transfer_postgres_to_ftps_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(
-        df,
-        init_df,
-        file_format=format_name,
-        transfer_direction="db_to_file",
-    )
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
 
@@ -328,12 +308,7 @@ async def test_run_transfer_postgres_to_ftps_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, first_transfer_df = prepare_dataframes_for_comparison(
-        df,
-        first_transfer_df,
-        file_format=format_name,
-        transfer_direction="db_to_file",
-    )
+    df, first_transfer_df = cast_dataframe_types(df, first_transfer_df)
     assert df.sort("id").collect() == first_transfer_df.sort("id").collect()
 
     fill_with_data(second_transfer_df)
@@ -343,10 +318,5 @@ async def test_run_transfer_postgres_to_ftps_with_incremental_strategy(
     verify_file_name_template(os.listdir(tmp_path), expected_extension)
 
     df_with_increment = reader.run()
-    df_with_increment, second_transfer_df = prepare_dataframes_for_comparison(
-        df_with_increment,
-        second_transfer_df,
-        file_format=format_name,
-        transfer_direction="db_to_file",
-    )
+    df, second_transfer_df = cast_dataframe_types(df, second_transfer_df)
     assert df_with_increment.sort("id").collect() == init_df.sort("id").collect()

--- a/tests/test_integration/test_run_transfer/test_hdfs.py
+++ b/tests/test_integration/test_run_transfer/test_hdfs.py
@@ -7,7 +7,7 @@ from httpx import AsyncClient
 from onetl.connection import HDFS, SparkHDFS
 from onetl.db import DBReader
 from onetl.file import FileDFReader
-from pyspark.sql import DataFrame
+from pyspark.sql import DataFrame, SparkSession
 from pytest_lazy_fixtures import lf
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -16,9 +16,10 @@ from syncmaster.db.models.transfer import Transfer
 from tests.mocks import MockUser
 from tests.test_unit.utils import create_transfer
 from tests.utils import (
-    prepare_dataframes_for_comparison,
+    cast_dataframe_types,
     run_transfer_and_verify,
     split_df,
+    truncate_datetime_to_seconds,
     verify_file_name_template,
 )
 
@@ -169,12 +170,10 @@ async def test_run_transfer_hdfs_to_postgres_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(
-        df,
-        init_df,
-        file_format=file_format,
-        transfer_direction="file_to_db",
-    )
+    if file_format == "excel":
+        df, init_df = truncate_datetime_to_seconds(df, init_df, transfer_direction="file_to_db")
+
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
 
@@ -227,6 +226,7 @@ async def test_run_transfer_hdfs_to_postgres_with_full_strategy(
     indirect=["target_file_format", "file_format_flavor"],
 )
 async def test_run_transfer_postgres_to_hdfs_with_full_strategy(
+    spark: SparkSession,
     group_owner: MockUser,
     init_df: DataFrame,
     client: AsyncClient,
@@ -250,6 +250,7 @@ async def test_run_transfer_postgres_to_hdfs_with_full_strategy(
     files = [os.fspath(file) for file in hdfs_file_connection.list_dir(target_path) if file.is_file()]
     verify_file_name_template(files, expected_extension)
 
+    spark.catalog.clearCache()
     reader = FileDFReader(
         connection=hdfs_file_df_connection,
         format=format,
@@ -259,12 +260,10 @@ async def test_run_transfer_postgres_to_hdfs_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(
-        df,
-        init_df,
-        file_format=format_name,
-        transfer_direction="db_to_file",
-    )
+    if format_name == "excel":
+        df, init_df = truncate_datetime_to_seconds(df, init_df, transfer_direction="db_to_file")
+
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
 
@@ -282,6 +281,7 @@ async def test_run_transfer_postgres_to_hdfs_with_full_strategy(
     indirect=["target_file_format", "file_format_flavor"],
 )
 async def test_run_transfer_postgres_to_hdfs_with_incremental_strategy(
+    spark: SparkSession,
     group_owner: MockUser,
     init_df: DataFrame,
     client: AsyncClient,
@@ -306,6 +306,7 @@ async def test_run_transfer_postgres_to_hdfs_with_incremental_strategy(
     files = [os.fspath(file) for file in hdfs_file_connection.list_dir(target_path) if file.is_file()]
     verify_file_name_template(files, expected_extension)
 
+    spark.catalog.clearCache()
     reader = FileDFReader(
         connection=hdfs_file_df_connection,
         format=format,
@@ -315,12 +316,7 @@ async def test_run_transfer_postgres_to_hdfs_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, first_transfer_df = prepare_dataframes_for_comparison(
-        df,
-        first_transfer_df,
-        file_format=format_name,
-        transfer_direction="db_to_file",
-    )
+    df, first_transfer_df = cast_dataframe_types(df, first_transfer_df)
     assert df.sort("id").collect() == first_transfer_df.sort("id").collect()
 
     fill_with_data(second_transfer_df)
@@ -329,11 +325,7 @@ async def test_run_transfer_postgres_to_hdfs_with_incremental_strategy(
     files = [os.fspath(file) for file in hdfs_file_connection.list_dir(target_path) if file.is_file()]
     verify_file_name_template(files, expected_extension)
 
+    spark.catalog.clearCache()
     df_with_increment = reader.run()
-    df_with_increment, init_df = prepare_dataframes_for_comparison(
-        df_with_increment,
-        init_df,
-        file_format=format_name,
-        transfer_direction="db_to_file",
-    )
+    df_with_increment, init_df = cast_dataframe_types(df_with_increment, init_df)
     assert df_with_increment.sort("id").collect() == init_df.sort("id").collect()

--- a/tests/test_integration/test_run_transfer/test_hdfs.py
+++ b/tests/test_integration/test_run_transfer/test_hdfs.py
@@ -8,22 +8,21 @@ from onetl.connection import HDFS, SparkHDFS
 from onetl.db import DBReader
 from onetl.file import FileDFReader
 from pyspark.sql import DataFrame
-from pyspark.sql.functions import col, date_format, date_trunc, to_timestamp
-from pytest import FixtureRequest
+from pytest_lazy_fixtures import lf
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from syncmaster.db.models import Connection, Group, Queue, Status
+from syncmaster.db.models import Connection, Group, Queue
 from syncmaster.db.models.transfer import Transfer
 from tests.mocks import MockUser
 from tests.test_unit.utils import create_transfer
-from tests.utils import get_run_on_end
+from tests.utils import (
+    prepare_dataframes_for_comparison,
+    run_transfer_and_verify,
+    split_df,
+    verify_file_name_template,
+)
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.worker]
-
-
-@pytest.fixture(params=[""])
-def file_format_flavor(request: FixtureRequest):
-    return request.param
 
 
 @pytest_asyncio.fixture
@@ -78,6 +77,7 @@ async def postgres_to_hdfs(
     postgres_connection: Connection,
     target_file_format,
     file_format_flavor: str,
+    strategy: dict,
 ):
     format_name, file_format = target_file_format
     result = await create_transfer(
@@ -100,6 +100,7 @@ async def postgres_to_hdfs(
             "file_name_template": "{run_created_at}-{index}.{extension}",
             "options": {},
         },
+        strategy_params=strategy,
         queue_id=queue.id,
     )
     yield result
@@ -148,7 +149,7 @@ async def postgres_to_hdfs(
     ],
     indirect=["source_file_format", "file_format_flavor"],
 )
-async def test_run_transfer_hdfs_to_postgres(
+async def test_run_transfer_hdfs_to_postgres_with_full_strategy(
     prepare_postgres,
     group_owner: MockUser,
     init_df: DataFrame,
@@ -157,32 +158,10 @@ async def test_run_transfer_hdfs_to_postgres(
     source_file_format,
     file_format_flavor,
 ):
-    # Arrange
     postgres, _ = prepare_postgres
     file_format, _ = source_file_format
 
-    # Act
-    result = await client.post(
-        "v1/runs",
-        headers={"Authorization": f"Bearer {group_owner.token}"},
-        json={"transfer_id": hdfs_to_postgres.id},
-    )
-    # Assert
-    assert result.status_code == 200
-
-    run_data = await get_run_on_end(
-        client=client,
-        run_id=result.json()["id"],
-        token=group_owner.token,
-    )
-    source_auth_data = run_data["transfer_dump"]["source_connection"]["auth_data"]
-    target_auth_data = run_data["transfer_dump"]["target_connection"]["auth_data"]
-
-    assert run_data["status"] == Status.FINISHED.value
-    assert source_auth_data["user"]
-    assert "password" not in source_auth_data
-    assert target_auth_data["user"]
-    assert "password" not in target_auth_data
+    await run_transfer_and_verify(client, group_owner, hdfs_to_postgres.id)
 
     reader = DBReader(
         connection=postgres,
@@ -190,60 +169,64 @@ async def test_run_transfer_hdfs_to_postgres(
     )
     df = reader.run()
 
-    # as Excel does not support datetime values with precision greater than milliseconds
-    if file_format == "excel":
-        df = df.withColumn("REGISTERED_AT", date_trunc("second", col("REGISTERED_AT")))
-        init_df = init_df.withColumn("REGISTERED_AT", date_trunc("second", col("REGISTERED_AT")))
-
-    for field in init_df.schema:
-        df = df.withColumn(field.name, df[field.name].cast(field.dataType))
-
+    df, init_df = prepare_dataframes_for_comparison(
+        df,
+        init_df,
+        file_format=file_format,
+        transfer_direction="file_to_db",
+    )
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
 
 @pytest.mark.parametrize(
-    "target_file_format, file_format_flavor, expected_extension",
+    "target_file_format, file_format_flavor, strategy, expected_extension",
     [
         pytest.param(
             ("csv", {"compression": "lz4"}),
             "with_compression",
+            lf("full_strategy"),
             "csv.lz4",
             id="csv",
         ),
         pytest.param(
             ("jsonline", {}),
             "without_compression",
+            lf("full_strategy"),
             "jsonl",
             id="jsonline",
         ),
         pytest.param(
             ("excel", {}),
             "with_header",
+            lf("full_strategy"),
             "xlsx",
             id="excel",
         ),
         pytest.param(
             ("orc", {"compression": "snappy"}),
             "with_compression",
+            lf("full_strategy"),
             "snappy.orc",
             id="orc",
         ),
         pytest.param(
             ("parquet", {"compression": "lz4"}),
             "with_compression",
+            lf("full_strategy"),
             "lz4hadoop.parquet",
             id="parquet",
         ),
         pytest.param(
             ("xml", {"compression": "snappy"}),
             "with_compression",
+            lf("full_strategy"),
             "xml.snappy",
             id="xml",
         ),
     ],
     indirect=["target_file_format", "file_format_flavor"],
 )
-async def test_run_transfer_postgres_to_hdfs(
+async def test_run_transfer_postgres_to_hdfs_with_full_strategy(
     group_owner: MockUser,
     init_df: DataFrame,
     client: AsyncClient,
@@ -254,61 +237,111 @@ async def test_run_transfer_postgres_to_hdfs(
     hdfs_connection: SparkHDFS,
     target_file_format,
     file_format_flavor: str,
+    strategy: dict,
     expected_extension: str,
 ):
     format_name, format = target_file_format
-    source_path = f"/target/{format_name}/{file_format_flavor}"
-
-    # Arrange
+    target_path = f"/target/{format_name}/{file_format_flavor}"
     _, fill_with_data = prepare_postgres
     fill_with_data(init_df)
 
-    # Act
-    result = await client.post(
-        "v1/runs",
-        headers={"Authorization": f"Bearer {group_owner.token}"},
-        json={"transfer_id": postgres_to_hdfs.id},
-    )
-    # Assert
-    assert result.status_code == 200
+    await run_transfer_and_verify(client, group_owner, postgres_to_hdfs.id)
 
-    run_data = await get_run_on_end(
-        client=client,
-        run_id=result.json()["id"],
-        token=group_owner.token,
-    )
-    source_auth_data = run_data["transfer_dump"]["source_connection"]["auth_data"]
-    target_auth_data = run_data["transfer_dump"]["target_connection"]["auth_data"]
-
-    assert run_data["status"] == Status.FINISHED.value
-    assert source_auth_data["user"]
-    assert "password" not in source_auth_data
-    assert target_auth_data["user"]
-    assert "password" not in target_auth_data
-
-    files = [os.fspath(file) for file in hdfs_file_connection.list_dir(source_path) if file.is_file()]
-    for file_name in files:
-        run_created_at, index_and_extension = file_name.split("-")
-        assert len(run_created_at.split("_")) == 6, f"Got wrong {run_created_at=}"
-        assert index_and_extension.split(".", 1)[1] == expected_extension
+    files = [os.fspath(file) for file in hdfs_file_connection.list_dir(target_path) if file.is_file()]
+    verify_file_name_template(files, expected_extension)
 
     reader = FileDFReader(
         connection=hdfs_file_df_connection,
         format=format,
-        source_path=source_path,
+        source_path=target_path,
         df_schema=init_df.schema,
         options={},
     )
     df = reader.run()
 
-    # as Excel does not support datetime values with precision greater than milliseconds
-    if format_name == "excel":
-        init_df = init_df.withColumn(
-            "REGISTERED_AT",
-            to_timestamp(date_format(col("REGISTERED_AT"), "yyyy-MM-dd HH:mm:ss.SSS")),
-        )
-
-    for field in init_df.schema:
-        df = df.withColumn(field.name, df[field.name].cast(field.dataType))
-
+    df, init_df = prepare_dataframes_for_comparison(
+        df,
+        init_df,
+        file_format=format_name,
+        transfer_direction="db_to_file",
+    )
     assert df.sort("id").collect() == init_df.sort("id").collect()
+
+
+@pytest.mark.parametrize(
+    "target_file_format, file_format_flavor, strategy, expected_extension",
+    [
+        pytest.param(
+            ("csv", {"compression": "lz4"}),
+            "with_compression",
+            lf("incremental_strategy_by_number_column"),
+            "csv.lz4",
+            id="csv",
+        ),
+    ],
+    indirect=["target_file_format", "file_format_flavor"],
+)
+async def test_run_transfer_postgres_to_hdfs_with_incremental_strategy(
+    group_owner: MockUser,
+    init_df: DataFrame,
+    client: AsyncClient,
+    prepare_postgres,
+    hdfs_file_df_connection: SparkHDFS,
+    hdfs_file_connection: HDFS,
+    postgres_to_hdfs: Transfer,
+    hdfs_connection: SparkHDFS,
+    target_file_format,
+    file_format_flavor: str,
+    strategy: dict,
+    expected_extension: str,
+):
+    format_name, format = target_file_format
+    target_path = f"/target/{format_name}/{file_format_flavor}"
+    _, fill_with_data = prepare_postgres
+
+    first_transfer_df, second_transfer_df = split_df(df=init_df, ratio=0.6, keep_sorted_by="number")
+    fill_with_data(first_transfer_df)
+    await run_transfer_and_verify(client, group_owner, postgres_to_hdfs.id)
+
+    files = [os.fspath(file) for file in hdfs_file_connection.list_dir(target_path) if file.is_file()]
+    verify_file_name_template(files, expected_extension)
+
+    reader = FileDFReader(
+        connection=hdfs_file_df_connection,
+        format=format,
+        source_path=target_path,
+        df_schema=init_df.schema,
+        options={},
+    )
+    df = reader.run()
+
+    df, first_transfer_df = prepare_dataframes_for_comparison(
+        df,
+        first_transfer_df,
+        file_format=format_name,
+        transfer_direction="db_to_file",
+    )
+    assert df.sort("id").collect() == first_transfer_df.sort("id").collect()
+
+    fill_with_data(second_transfer_df)
+    await run_transfer_and_verify(client, group_owner, postgres_to_hdfs.id)
+
+    files = [os.fspath(file) for file in hdfs_file_connection.list_dir(target_path) if file.is_file()]
+    verify_file_name_template(files, expected_extension)
+
+    reader = FileDFReader(
+        connection=hdfs_file_df_connection,
+        format=format,
+        source_path=target_path,
+        df_schema=init_df.schema,
+        options={},
+    )
+    df_with_increment = reader.run()
+
+    df_with_increment, init_df = prepare_dataframes_for_comparison(
+        df_with_increment,
+        init_df,
+        file_format=format_name,
+        transfer_direction="db_to_file",
+    )
+    assert df_with_increment.sort("id").collect() == init_df.sort("id").collect()

--- a/tests/test_integration/test_run_transfer/test_hdfs.py
+++ b/tests/test_integration/test_run_transfer/test_hdfs.py
@@ -329,15 +329,7 @@ async def test_run_transfer_postgres_to_hdfs_with_incremental_strategy(
     files = [os.fspath(file) for file in hdfs_file_connection.list_dir(target_path) if file.is_file()]
     verify_file_name_template(files, expected_extension)
 
-    reader = FileDFReader(
-        connection=hdfs_file_df_connection,
-        format=format,
-        source_path=target_path,
-        df_schema=init_df.schema,
-        options={},
-    )
     df_with_increment = reader.run()
-
     df_with_increment, init_df = prepare_dataframes_for_comparison(
         df_with_increment,
         init_df,

--- a/tests/test_integration/test_run_transfer/test_hive.py
+++ b/tests/test_integration/test_run_transfer/test_hive.py
@@ -197,12 +197,7 @@ async def test_run_transfer_postgres_to_hive_with_incremental_strategy(
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, postgres_to_hive.id)
 
-    reader = DBReader(
-        connection=hive,
-        table="default.target_table",
-    )
     df_with_increment = reader.run()
-
     df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df)
     assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()
 
@@ -329,11 +324,6 @@ async def test_run_transfer_hive_to_postgres_with_incremental_strategy(
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, hive_to_postgres.id)
 
-    reader = DBReader(
-        connection=postgres,
-        table="public.target_table",
-    )
     df_with_increment = reader.run()
-
     df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df)
     assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()

--- a/tests/test_integration/test_run_transfer/test_hive.py
+++ b/tests/test_integration/test_run_transfer/test_hive.py
@@ -4,7 +4,7 @@ import pytest
 import pytest_asyncio
 from httpx import AsyncClient
 from onetl.db import DBReader
-from pyspark.sql import DataFrame
+from pyspark.sql import DataFrame, SparkSession
 from pytest_lazy_fixtures import lf
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -169,6 +169,7 @@ async def test_run_transfer_postgres_to_hive_mixed_naming_with_full_strategy(
     ],
 )
 async def test_run_transfer_postgres_to_hive_with_incremental_strategy(
+    spark: SparkSession,
     client: AsyncClient,
     group_owner: MockUser,
     prepare_postgres,
@@ -197,6 +198,7 @@ async def test_run_transfer_postgres_to_hive_with_incremental_strategy(
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, postgres_to_hive.id)
 
+    spark.catalog.refreshTable("default.target_table")
     df_with_increment = reader.run()
     df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df)
     assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()

--- a/tests/test_integration/test_run_transfer/test_hive.py
+++ b/tests/test_integration/test_run_transfer/test_hive.py
@@ -12,7 +12,7 @@ from syncmaster.db.models import Connection, Group, Queue, Transfer
 from tests.mocks import MockUser
 from tests.test_unit.utils import create_transfer
 from tests.utils import (
-    prepare_dataframes_for_comparison,
+    cast_dataframe_types,
     run_transfer_and_verify,
     split_df,
 )
@@ -117,7 +117,7 @@ async def test_run_transfer_postgres_to_hive_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(df, init_df)
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("ID").collect() == init_df.sort("ID").collect()
 
 
@@ -155,7 +155,7 @@ async def test_run_transfer_postgres_to_hive_mixed_naming_with_full_strategy(
     assert df.columns != init_df_with_mixed_column_naming.columns
     assert df.columns == [column.lower() for column in init_df_with_mixed_column_naming.columns]
 
-    df, init_df_with_mixed_column_naming = prepare_dataframes_for_comparison(df, init_df_with_mixed_column_naming)
+    df, init_df_with_mixed_column_naming = cast_dataframe_types(df, init_df_with_mixed_column_naming)
     assert df.sort("ID").collect() == init_df_with_mixed_column_naming.sort("ID").collect()
 
 
@@ -192,7 +192,7 @@ async def test_run_transfer_postgres_to_hive_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, first_transfer_df = prepare_dataframes_for_comparison(df, first_transfer_df)
+    df, first_transfer_df = cast_dataframe_types(df, first_transfer_df)
     assert df.sort("ID").collect() == first_transfer_df.sort("ID").collect()
 
     fill_with_data(second_transfer_df)
@@ -200,7 +200,7 @@ async def test_run_transfer_postgres_to_hive_with_incremental_strategy(
 
     spark.catalog.refreshTable("default.target_table")
     df_with_increment = reader.run()
-    df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df)
+    df_with_increment, init_df = cast_dataframe_types(df_with_increment, init_df)
     assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()
 
 
@@ -246,7 +246,7 @@ async def test_run_transfer_hive_to_postgres_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(df, init_df)
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("ID").collect() == init_df.sort("ID").collect()
 
 
@@ -284,7 +284,7 @@ async def test_run_transfer_hive_to_postgres_mixes_naming_with_full_strategy(
     assert df.columns != init_df_with_mixed_column_naming.columns
     assert df.columns == [column.lower() for column in init_df_with_mixed_column_naming.columns]
 
-    df, init_df_with_mixed_column_naming = prepare_dataframes_for_comparison(df, init_df_with_mixed_column_naming)
+    df, init_df_with_mixed_column_naming = cast_dataframe_types(df, init_df_with_mixed_column_naming)
     assert df.sort("ID").collect() == init_df_with_mixed_column_naming.sort("ID").collect()
 
 
@@ -320,12 +320,12 @@ async def test_run_transfer_hive_to_postgres_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, first_transfer_df = prepare_dataframes_for_comparison(df, first_transfer_df)
+    df, first_transfer_df = cast_dataframe_types(df, first_transfer_df)
     assert df.sort("ID").collect() == first_transfer_df.sort("ID").collect()
 
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, hive_to_postgres.id)
 
     df_with_increment = reader.run()
-    df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df)
+    df_with_increment, init_df = cast_dataframe_types(df_with_increment, init_df)
     assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()

--- a/tests/test_integration/test_run_transfer/test_mssql.py
+++ b/tests/test_integration/test_run_transfer/test_mssql.py
@@ -210,12 +210,7 @@ async def test_run_transfer_postgres_to_mssql_with_incremental_strategy(
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, postgres_to_mssql.id)
 
-    reader = DBReader(
-        connection=mssql,
-        table="dbo.target_table",
-    )
     df_with_increment = reader.run()
-
     df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df, db_type="mssql")
     assert df.sort("ID").collect() == init_df.sort("ID").collect()
 
@@ -351,11 +346,6 @@ async def test_run_transfer_mssql_to_postgres_with_incremental_strategy(
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, mssql_to_postgres.id)
 
-    reader = DBReader(
-        connection=postgres,
-        table="public.target_table",
-    )
     df_with_increment = reader.run()
-
     df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df, db_type="mssql")
     assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()

--- a/tests/test_integration/test_run_transfer/test_mssql.py
+++ b/tests/test_integration/test_run_transfer/test_mssql.py
@@ -14,9 +14,10 @@ from syncmaster.db.models import Connection, Group, Queue, Transfer
 from tests.mocks import MockUser
 from tests.test_unit.utils import create_transfer
 from tests.utils import (
-    prepare_dataframes_for_comparison,
+    cast_dataframe_types,
     run_transfer_and_verify,
     split_df,
+    truncate_datetime_to_seconds,
 )
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.worker]
@@ -121,7 +122,8 @@ async def test_run_transfer_postgres_to_mssql_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(df, init_df, db_type="mssql")
+    df, init_df = truncate_datetime_to_seconds(df, init_df)
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("ID").collect() == init_df.sort("ID").collect()
 
 
@@ -204,14 +206,16 @@ async def test_run_transfer_postgres_to_mssql_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, first_transfer_df = prepare_dataframes_for_comparison(df, first_transfer_df, db_type="mssql")
+    df, first_transfer_df = truncate_datetime_to_seconds(df, first_transfer_df)
+    df, first_transfer_df = cast_dataframe_types(df, first_transfer_df)
     assert df.sort("ID").collect() == first_transfer_df.sort("ID").collect()
 
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, postgres_to_mssql.id)
 
     df_with_increment = reader.run()
-    df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df, db_type="mssql")
+    df_with_increment, init_df = truncate_datetime_to_seconds(df_with_increment, init_df)
+    df_with_increment, init_df = cast_dataframe_types(df_with_increment, init_df)
     assert df.sort("ID").collect() == init_df.sort("ID").collect()
 
 
@@ -257,7 +261,8 @@ async def test_run_transfer_mssql_to_postgres_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(df, init_df, db_type="mssql")
+    df, init_df = truncate_datetime_to_seconds(df, init_df)
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("ID").collect() == init_df.sort("ID").collect()
 
 
@@ -340,12 +345,14 @@ async def test_run_transfer_mssql_to_postgres_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, first_transfer_df = prepare_dataframes_for_comparison(df, first_transfer_df, db_type="mssql")
+    df, first_transfer_df = truncate_datetime_to_seconds(df, first_transfer_df)
+    df, first_transfer_df = cast_dataframe_types(df, first_transfer_df)
     assert df.sort("ID").collect() == first_transfer_df.sort("ID").collect()
 
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, mssql_to_postgres.id)
 
     df_with_increment = reader.run()
-    df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df, db_type="mssql")
+    df_with_increment, init_df = truncate_datetime_to_seconds(df_with_increment, init_df)
+    df_with_increment, init_df = cast_dataframe_types(df_with_increment, init_df)
     assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()

--- a/tests/test_integration/test_run_transfer/test_mysql.py
+++ b/tests/test_integration/test_run_transfer/test_mysql.py
@@ -212,12 +212,7 @@ async def test_run_transfer_postgres_to_mysql_with_incremental_strategy(
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, postgres_to_mysql.id)
 
-    reader = DBReader(
-        connection=mysql,
-        table=f"{mysql.database}.target_table",
-    )
     df_with_increment = reader.run()
-
     df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df, db_type="mysql")
     assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()
 
@@ -355,11 +350,6 @@ async def test_run_transfer_mysql_to_postgres_with_incremental_strategy(
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, mysql_to_postgres.id)
 
-    reader = DBReader(
-        connection=postgres,
-        table="public.target_table",
-    )
     df_with_increment = reader.run()
-
     df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df, db_type="mysql")
     assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()

--- a/tests/test_integration/test_run_transfer/test_mysql.py
+++ b/tests/test_integration/test_run_transfer/test_mysql.py
@@ -14,7 +14,8 @@ from syncmaster.db.models import Connection, Group, Queue, Transfer
 from tests.mocks import MockUser
 from tests.test_unit.utils import create_transfer
 from tests.utils import (
-    prepare_dataframes_for_comparison,
+    cast_dataframe_types,
+    round_datetime_to_seconds,
     run_transfer_and_verify,
     split_df,
 )
@@ -121,7 +122,8 @@ async def test_run_transfer_postgres_to_mysql_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(df, init_df, db_type="mysql")
+    df, init_df = round_datetime_to_seconds(df, init_df)
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("ID").collect() == init_df.sort("ID").collect()
 
 
@@ -206,14 +208,16 @@ async def test_run_transfer_postgres_to_mysql_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, first_transfer_df = prepare_dataframes_for_comparison(df, first_transfer_df, db_type="mysql")
+    df, first_transfer_df = round_datetime_to_seconds(df, first_transfer_df)
+    df, first_transfer_df = cast_dataframe_types(df, first_transfer_df)
     assert df.sort("ID").collect() == first_transfer_df.sort("ID").collect()
 
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, postgres_to_mysql.id)
 
     df_with_increment = reader.run()
-    df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df, db_type="mysql")
+    df_with_increment, init_df = round_datetime_to_seconds(df_with_increment, init_df)
+    df_with_increment, init_df = cast_dataframe_types(df_with_increment, init_df)
     assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()
 
 
@@ -259,7 +263,8 @@ async def test_run_transfer_mysql_to_postgres_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(df, init_df, db_type="mysql")
+    df, init_df = round_datetime_to_seconds(df, init_df)
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("ID").collect() == init_df.sort("ID").collect()
 
 
@@ -344,12 +349,14 @@ async def test_run_transfer_mysql_to_postgres_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, first_transfer_df = prepare_dataframes_for_comparison(df, first_transfer_df, db_type="mysql")
+    df, first_transfer_df = round_datetime_to_seconds(df, first_transfer_df)
+    df, first_transfer_df = cast_dataframe_types(df, first_transfer_df)
     assert df.sort("ID").collect() == first_transfer_df.sort("ID").collect()
 
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, mysql_to_postgres.id)
 
     df_with_increment = reader.run()
-    df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df, db_type="mysql")
+    df_with_increment, init_df = round_datetime_to_seconds(df_with_increment, init_df)
+    df_with_increment, init_df = cast_dataframe_types(df_with_increment, init_df)
     assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()

--- a/tests/test_integration/test_run_transfer/test_oracle.py
+++ b/tests/test_integration/test_run_transfer/test_oracle.py
@@ -13,7 +13,7 @@ from syncmaster.db.models import Connection, Group, Queue, Transfer
 from tests.mocks import MockUser
 from tests.test_unit.utils import create_transfer
 from tests.utils import (
-    prepare_dataframes_for_comparison,
+    cast_dataframe_types,
     run_transfer_and_verify,
     split_df,
 )
@@ -120,7 +120,7 @@ async def test_run_transfer_postgres_to_oracle_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(df, init_df)
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("ID").collect() == init_df.sort("ID").collect()
 
 
@@ -158,7 +158,7 @@ async def test_run_transfer_postgres_to_oracle_mixed_naming_with_full_strategy(
     assert df.columns != init_df_with_mixed_column_naming.columns
     assert df.columns == [column.upper() for column in init_df_with_mixed_column_naming.columns]
 
-    df, init_df_with_mixed_column_naming = prepare_dataframes_for_comparison(df, init_df_with_mixed_column_naming)
+    df, init_df_with_mixed_column_naming = cast_dataframe_types(df, init_df_with_mixed_column_naming)
     assert df.sort("ID").collect() == init_df_with_mixed_column_naming.sort("ID").collect()
 
 
@@ -194,14 +194,14 @@ async def test_run_transfer_postgres_to_oracle_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, first_transfer_df = prepare_dataframes_for_comparison(df, first_transfer_df)
+    df, first_transfer_df = cast_dataframe_types(df, first_transfer_df)
     assert df.sort("ID").collect() == first_transfer_df.sort("ID").collect()
 
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, postgres_to_oracle.id)
 
     df_with_increment = reader.run()
-    df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df)
+    df_with_increment, init_df = cast_dataframe_types(df_with_increment, init_df)
     assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()
 
 
@@ -247,7 +247,7 @@ async def test_run_transfer_oracle_to_postgres_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(df, init_df)
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("ID").collect() == init_df.sort("ID").collect()
 
 
@@ -285,7 +285,7 @@ async def test_run_transfer_oracle_to_postgres_mixed_naming_with_full_strategy(
     assert df.columns != init_df_with_mixed_column_naming.columns
     assert df.columns == [column.lower() for column in init_df_with_mixed_column_naming.columns]
 
-    df, init_df_with_mixed_column_naming = prepare_dataframes_for_comparison(df, init_df_with_mixed_column_naming)
+    df, init_df_with_mixed_column_naming = cast_dataframe_types(df, init_df_with_mixed_column_naming)
     assert df.sort("ID").collect() == init_df_with_mixed_column_naming.sort("ID").collect()
 
 
@@ -321,12 +321,12 @@ async def test_run_transfer_oracle_to_postgres_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, first_transfer_df = prepare_dataframes_for_comparison(df, first_transfer_df)
+    df, first_transfer_df = cast_dataframe_types(df, first_transfer_df)
     assert df.sort("ID").collect() == first_transfer_df.sort("ID").collect()
 
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, oracle_to_postgres.id)
 
     df_with_increment = reader.run()
-    df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df)
+    df_with_increment, init_df = cast_dataframe_types(df_with_increment, init_df)
     assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()

--- a/tests/test_integration/test_run_transfer/test_oracle.py
+++ b/tests/test_integration/test_run_transfer/test_oracle.py
@@ -9,10 +9,14 @@ from pyspark.sql import DataFrame
 from pytest_lazy_fixtures import lf
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from syncmaster.db.models import Connection, Group, Queue, Status, Transfer
+from syncmaster.db.models import Connection, Group, Queue, Transfer
 from tests.mocks import MockUser
 from tests.test_unit.utils import create_transfer
-from tests.utils import get_run_on_end
+from tests.utils import (
+    prepare_dataframes_for_comparison,
+    run_transfer_and_verify,
+    split_df,
+)
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.worker]
 
@@ -25,6 +29,7 @@ async def postgres_to_oracle(
     oracle_for_conftest: Oracle,
     oracle_connection: Connection,
     postgres_connection: Connection,
+    strategy: dict,
     transformations: list[dict],
 ):
     result = await create_transfer(
@@ -41,6 +46,7 @@ async def postgres_to_oracle(
             "type": "oracle",
             "table_name": f"{oracle_for_conftest.user}.target_table",
         },
+        strategy_params=strategy,
         transformations=transformations,
         queue_id=queue.id,
     )
@@ -57,6 +63,7 @@ async def oracle_to_postgres(
     oracle_for_conftest: Oracle,
     oracle_connection: Connection,
     postgres_connection: Connection,
+    strategy: dict,
     transformations: list[dict],
 ):
     result = await create_transfer(
@@ -73,6 +80,7 @@ async def oracle_to_postgres(
             "type": "postgres",
             "table_name": "public.target_table",
         },
+        strategy_params=strategy,
         transformations=transformations,
         queue_id=queue.id,
     )
@@ -81,122 +89,145 @@ async def oracle_to_postgres(
     await session.commit()
 
 
-@pytest.mark.parametrize("transformations", [[]])
-async def test_run_transfer_postgres_to_oracle(
+@pytest.mark.parametrize(
+    "strategy, transformations",
+    [
+        (
+            lf("full_strategy"),
+            [],
+        ),
+    ],
+)
+async def test_run_transfer_postgres_to_oracle_with_full_strategy(
     client: AsyncClient,
     group_owner: MockUser,
     prepare_postgres,
     prepare_oracle,
     init_df: DataFrame,
     postgres_to_oracle: Transfer,
+    strategy,
     transformations,
 ):
-    # Arrange
     _, fill_with_data = prepare_postgres
     fill_with_data(init_df)
     oracle, _ = prepare_oracle
 
-    # Act
-    result = await client.post(
-        "v1/runs",
-        headers={"Authorization": f"Bearer {group_owner.token}"},
-        json={"transfer_id": postgres_to_oracle.id},
-    )
-    # Assert
-    assert result.status_code == 200
+    await run_transfer_and_verify(client, group_owner, postgres_to_oracle.id)
 
-    run_data = await get_run_on_end(
-        client=client,
-        run_id=result.json()["id"],
-        token=group_owner.token,
-    )
-    source_auth_data = run_data["transfer_dump"]["source_connection"]["auth_data"]
-    target_auth_data = run_data["transfer_dump"]["target_connection"]["auth_data"]
-
-    assert run_data["status"] == Status.FINISHED.value
-    assert source_auth_data["user"]
-    assert "password" not in source_auth_data
-    assert target_auth_data["user"]
-    assert "password" not in target_auth_data
     reader = DBReader(
         connection=oracle,
         table=f"{oracle.user}.target_table",
     )
     df = reader.run()
-    for field in init_df.schema:
-        df = df.withColumn(field.name, df[field.name].cast(field.dataType))
 
+    df, init_df = prepare_dataframes_for_comparison(df, init_df)
     assert df.sort("ID").collect() == init_df.sort("ID").collect()
 
 
-@pytest.mark.parametrize("transformations", [[]])
-async def test_run_transfer_postgres_to_oracle_mixed_naming(
+@pytest.mark.parametrize(
+    "strategy, transformations",
+    [
+        (
+            lf("full_strategy"),
+            [],
+        ),
+    ],
+)
+async def test_run_transfer_postgres_to_oracle_mixed_naming_with_full_strategy(
     client: AsyncClient,
     group_owner: MockUser,
     prepare_postgres,
     prepare_oracle,
     init_df_with_mixed_column_naming: DataFrame,
     postgres_to_oracle: Transfer,
+    strategy,
     transformations,
 ):
-    # Arrange
     _, fill_with_data = prepare_postgres
     fill_with_data(init_df_with_mixed_column_naming)
     oracle, _ = prepare_oracle
 
-    # Act
-    result = await client.post(
-        "v1/runs",
-        headers={"Authorization": f"Bearer {group_owner.token}"},
-        json={"transfer_id": postgres_to_oracle.id},
-    )
-    # Assert
-    assert result.status_code == 200
-
-    run_data = await get_run_on_end(
-        client=client,
-        run_id=result.json()["id"],
-        token=group_owner.token,
-    )
-    source_auth_data = run_data["transfer_dump"]["source_connection"]["auth_data"]
-    target_auth_data = run_data["transfer_dump"]["target_connection"]["auth_data"]
-
-    assert run_data["status"] == Status.FINISHED.value
-    assert source_auth_data["user"]
-    assert "password" not in source_auth_data
-    assert target_auth_data["user"]
-    assert "password" not in target_auth_data
+    await run_transfer_and_verify(client, group_owner, postgres_to_oracle.id)
 
     reader = DBReader(
         connection=oracle,
         table=f"{oracle.user}.target_table",
     )
     df = reader.run()
+
     assert df.columns != init_df_with_mixed_column_naming.columns
     assert df.columns == [column.upper() for column in init_df_with_mixed_column_naming.columns]
 
-    for field in init_df_with_mixed_column_naming.schema:
-        df = df.withColumn(field.name, df[field.name].cast(field.dataType))
-
+    df, init_df_with_mixed_column_naming = prepare_dataframes_for_comparison(df, init_df_with_mixed_column_naming)
     assert df.sort("ID").collect() == init_df_with_mixed_column_naming.sort("ID").collect()
 
 
 @pytest.mark.parametrize(
-    "source_type, transformations, expected_filter",
+    "strategy, transformations",
+    [
+        (
+            lf("incremental_strategy_by_number_column"),
+            [],
+        ),
+    ],
+)
+async def test_run_transfer_postgres_to_oracle_with_incremental_strategy(
+    client: AsyncClient,
+    group_owner: MockUser,
+    prepare_postgres,
+    prepare_oracle,
+    init_df: DataFrame,
+    postgres_to_oracle: Transfer,
+    strategy,
+    transformations,
+):
+    _, fill_with_data = prepare_postgres
+    oracle, _ = prepare_oracle
+
+    first_transfer_df, second_transfer_df = split_df(df=init_df, ratio=0.6, keep_sorted_by="number")
+    fill_with_data(first_transfer_df)
+    await run_transfer_and_verify(client, group_owner, postgres_to_oracle.id)
+
+    reader = DBReader(
+        connection=oracle,
+        table=f"{oracle.user}.target_table",
+    )
+    df = reader.run()
+
+    df, first_transfer_df = prepare_dataframes_for_comparison(df, first_transfer_df)
+    assert df.sort("ID").collect() == first_transfer_df.sort("ID").collect()
+
+    fill_with_data(second_transfer_df)
+    await run_transfer_and_verify(client, group_owner, postgres_to_oracle.id)
+
+    reader = DBReader(
+        connection=oracle,
+        table=f"{oracle.user}.target_table",
+    )
+    df_with_increment = reader.run()
+
+    df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df)
+    assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()
+
+
+@pytest.mark.parametrize(
+    "source_type, strategy, transformations, expected_filter",
     [
         (
             "oracle",
+            lf("incremental_strategy_by_number_column"),
             lf("dataframe_rows_filter_transformations"),
             lf("expected_dataframe_rows_filter"),
         ),
         (
             "oracle",
+            lf("incremental_strategy_by_number_column"),
             lf("dataframe_columns_filter_transformations"),
             lf("expected_dataframe_columns_filter"),
         ),
     ],
 )
-async def test_run_transfer_oracle_to_postgres(
+async def test_run_transfer_oracle_to_postgres_with_full_strategy(
     client: AsyncClient,
     group_owner: MockUser,
     prepare_oracle,
@@ -204,37 +235,16 @@ async def test_run_transfer_oracle_to_postgres(
     init_df: DataFrame,
     oracle_to_postgres: Transfer,
     source_type,
+    strategy,
     transformations,
     expected_filter,
 ):
-    # Arrange
     _, fill_with_data = prepare_oracle
     fill_with_data(init_df)
     postgres, _ = prepare_postgres
     init_df = expected_filter(init_df, source_type)
 
-    # Act
-    result = await client.post(
-        "v1/runs",
-        headers={"Authorization": f"Bearer {group_owner.token}"},
-        json={"transfer_id": oracle_to_postgres.id},
-    )
-    # Assert
-    assert result.status_code == 200
-
-    run_data = await get_run_on_end(
-        client=client,
-        run_id=result.json()["id"],
-        token=group_owner.token,
-    )
-    source_auth_data = run_data["transfer_dump"]["source_connection"]["auth_data"]
-    target_auth_data = run_data["transfer_dump"]["target_connection"]["auth_data"]
-
-    assert run_data["status"] == Status.FINISHED.value
-    assert source_auth_data["user"]
-    assert "password" not in source_auth_data
-    assert target_auth_data["user"]
-    assert "password" not in target_auth_data
+    await run_transfer_and_verify(client, group_owner, oracle_to_postgres.id)
 
     reader = DBReader(
         connection=postgres,
@@ -242,49 +252,34 @@ async def test_run_transfer_oracle_to_postgres(
     )
     df = reader.run()
 
-    for field in init_df.schema:
-        df = df.withColumn(field.name, df[field.name].cast(field.dataType))
-
+    df, init_df = prepare_dataframes_for_comparison(df, init_df)
     assert df.sort("ID").collect() == init_df.sort("ID").collect()
 
 
-@pytest.mark.parametrize("transformations", [[]])
-async def test_run_transfer_oracle_to_postgres_mixed_naming(
+@pytest.mark.parametrize(
+    "strategy, transformations",
+    [
+        (
+            lf("full_strategy"),
+            [],
+        ),
+    ],
+)
+async def test_run_transfer_oracle_to_postgres_mixed_naming_with_full_strategy(
     client: AsyncClient,
     group_owner: MockUser,
     prepare_oracle,
     prepare_postgres,
     init_df_with_mixed_column_naming: DataFrame,
     oracle_to_postgres: Transfer,
+    strategy,
     transformations,
 ):
-    # Arrange
     _, fill_with_data = prepare_oracle
     fill_with_data(init_df_with_mixed_column_naming)
     postgres, _ = prepare_postgres
 
-    # Act
-    result = await client.post(
-        "v1/runs",
-        headers={"Authorization": f"Bearer {group_owner.token}"},
-        json={"transfer_id": oracle_to_postgres.id},
-    )
-    # Assert
-    assert result.status_code == 200
-
-    run_data = await get_run_on_end(
-        client=client,
-        run_id=result.json()["id"],
-        token=group_owner.token,
-    )
-    source_auth_data = run_data["transfer_dump"]["source_connection"]["auth_data"]
-    target_auth_data = run_data["transfer_dump"]["target_connection"]["auth_data"]
-
-    assert run_data["status"] == Status.FINISHED.value
-    assert source_auth_data["user"]
-    assert "password" not in source_auth_data
-    assert target_auth_data["user"]
-    assert "password" not in target_auth_data
+    await run_transfer_and_verify(client, group_owner, oracle_to_postgres.id)
 
     reader = DBReader(
         connection=postgres,
@@ -295,7 +290,53 @@ async def test_run_transfer_oracle_to_postgres_mixed_naming(
     assert df.columns != init_df_with_mixed_column_naming.columns
     assert df.columns == [column.lower() for column in init_df_with_mixed_column_naming.columns]
 
-    for field in init_df_with_mixed_column_naming.schema:
-        df = df.withColumn(field.name, df[field.name].cast(field.dataType))
-
+    df, init_df_with_mixed_column_naming = prepare_dataframes_for_comparison(df, init_df_with_mixed_column_naming)
     assert df.sort("ID").collect() == init_df_with_mixed_column_naming.sort("ID").collect()
+
+
+@pytest.mark.parametrize(
+    "strategy, transformations",
+    [
+        (
+            lf("incremental_strategy_by_number_column"),
+            [],
+        ),
+    ],
+)
+async def test_run_transfer_oracle_to_postgres_with_incremental_strategy(
+    client: AsyncClient,
+    group_owner: MockUser,
+    prepare_oracle,
+    prepare_postgres,
+    init_df: DataFrame,
+    oracle_to_postgres: Transfer,
+    strategy,
+    transformations,
+):
+    _, fill_with_data = prepare_oracle
+    postgres, _ = prepare_postgres
+
+    first_transfer_df, second_transfer_df = split_df(df=init_df, ratio=0.6, keep_sorted_by="number")
+    fill_with_data(first_transfer_df)
+    await run_transfer_and_verify(client, group_owner, oracle_to_postgres.id)
+
+    reader = DBReader(
+        connection=postgres,
+        table="public.target_table",
+    )
+    df = reader.run()
+
+    df, first_transfer_df = prepare_dataframes_for_comparison(df, first_transfer_df)
+    assert df.sort("ID").collect() == first_transfer_df.sort("ID").collect()
+
+    fill_with_data(second_transfer_df)
+    await run_transfer_and_verify(client, group_owner, oracle_to_postgres.id)
+
+    reader = DBReader(
+        connection=postgres,
+        table="public.target_table",
+    )
+    df_with_increment = reader.run()
+
+    df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df)
+    assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()

--- a/tests/test_integration/test_run_transfer/test_oracle.py
+++ b/tests/test_integration/test_run_transfer/test_oracle.py
@@ -200,12 +200,7 @@ async def test_run_transfer_postgres_to_oracle_with_incremental_strategy(
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, postgres_to_oracle.id)
 
-    reader = DBReader(
-        connection=oracle,
-        table=f"{oracle.user}.target_table",
-    )
     df_with_increment = reader.run()
-
     df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df)
     assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()
 
@@ -332,11 +327,6 @@ async def test_run_transfer_oracle_to_postgres_with_incremental_strategy(
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, oracle_to_postgres.id)
 
-    reader = DBReader(
-        connection=postgres,
-        table="public.target_table",
-    )
     df_with_increment = reader.run()
-
     df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df)
     assert df_with_increment.sort("ID").collect() == init_df.sort("ID").collect()

--- a/tests/test_integration/test_run_transfer/test_s3.py
+++ b/tests/test_integration/test_run_transfer/test_s3.py
@@ -8,23 +8,21 @@ from onetl.connection import S3, SparkS3
 from onetl.db import DBReader
 from onetl.file import FileDFReader
 from pyspark.sql import DataFrame
-from pyspark.sql.functions import col, date_format, date_trunc, to_timestamp
-from pytest import FixtureRequest
 from pytest_lazy_fixtures import lf
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from syncmaster.db.models import Connection, Group, Queue, Status
+from syncmaster.db.models import Connection, Group, Queue
 from syncmaster.db.models.transfer import Transfer
 from tests.mocks import MockUser
 from tests.test_unit.utils import create_transfer
-from tests.utils import get_run_on_end
+from tests.utils import (
+    prepare_dataframes_for_comparison,
+    run_transfer_and_verify,
+    split_df,
+    verify_file_name_template,
+)
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.worker]
-
-
-@pytest.fixture(params=[""])
-def file_format_flavor(request: FixtureRequest):
-    return request.param
 
 
 @pytest_asyncio.fixture
@@ -81,6 +79,7 @@ async def postgres_to_s3(
     postgres_connection: Connection,
     target_file_format,
     file_format_flavor: str,
+    strategy: dict,
     transformations: list[dict],
 ):
     format_name, file_format = target_file_format
@@ -104,6 +103,7 @@ async def postgres_to_s3(
             "file_name_template": "{run_created_at}-{index}.{extension}",
             "options": {},
         },
+        strategy_params=strategy,
         transformations=transformations,
         queue_id=queue.id,
     )
@@ -174,7 +174,7 @@ async def postgres_to_s3(
     ],
     indirect=["source_file_format", "file_format_flavor"],
 )
-async def test_run_transfer_s3_to_postgres(
+async def test_run_transfer_s3_to_postgres_with_full_strategy(
     prepare_postgres,
     group_owner: MockUser,
     init_df: DataFrame,
@@ -186,35 +186,12 @@ async def test_run_transfer_s3_to_postgres(
     transformations,
     expected_filter,
 ):
-    # Arrange
     postgres, _ = prepare_postgres
     file_format, _ = source_file_format
     if expected_filter:
         init_df = expected_filter(init_df, source_type)
 
-    # Act
-    result = await client.post(
-        "v1/runs",
-        headers={"Authorization": f"Bearer {group_owner.token}"},
-        json={"transfer_id": s3_to_postgres.id},
-    )
-    # Assert
-    assert result.status_code == 200
-
-    run_data = await get_run_on_end(
-        client=client,
-        run_id=result.json()["id"],
-        token=group_owner.token,
-    )
-
-    source_auth_data = run_data["transfer_dump"]["source_connection"]["auth_data"]
-    target_auth_data = run_data["transfer_dump"]["target_connection"]["auth_data"]
-
-    assert run_data["status"] == Status.FINISHED.value
-    assert source_auth_data["access_key"]
-    assert "secret_key" not in source_auth_data
-    assert target_auth_data["user"]
-    assert "password" not in target_auth_data
+    await run_transfer_and_verify(client, group_owner, s3_to_postgres.id, auth=("s3", "basic"))
 
     reader = DBReader(
         connection=postgres,
@@ -222,23 +199,22 @@ async def test_run_transfer_s3_to_postgres(
     )
     df = reader.run()
 
-    # as Excel does not support datetime values with precision greater than milliseconds
-    if file_format == "excel":
-        df = df.withColumn("REGISTERED_AT", date_trunc("second", col("REGISTERED_AT")))
-        init_df = init_df.withColumn("REGISTERED_AT", date_trunc("second", col("REGISTERED_AT")))
-
-    for field in init_df.schema:
-        df = df.withColumn(field.name, df[field.name].cast(field.dataType))
-
+    df, init_df = prepare_dataframes_for_comparison(
+        df,
+        init_df,
+        file_format=file_format,
+        transfer_direction="file_to_db",
+    )
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
 
 @pytest.mark.parametrize(
-    "target_file_format, file_format_flavor, transformations, expected_extension",
+    "target_file_format, file_format_flavor, strategy, transformations, expected_extension",
     [
         pytest.param(
             ("csv", {"compression": "lz4"}),
             "with_compression",
+            lf("full_strategy"),
             [],
             "csv.lz4",
             id="csv",
@@ -246,6 +222,7 @@ async def test_run_transfer_s3_to_postgres(
         pytest.param(
             ("jsonline", {}),
             "without_compression",
+            lf("full_strategy"),
             [],
             "jsonl",
             id="jsonline",
@@ -253,6 +230,7 @@ async def test_run_transfer_s3_to_postgres(
         pytest.param(
             ("excel", {}),
             "with_header",
+            lf("full_strategy"),
             [],
             "xlsx",
             id="excel",
@@ -260,6 +238,7 @@ async def test_run_transfer_s3_to_postgres(
         pytest.param(
             ("orc", {"compression": "none"}),
             "without_compression",
+            lf("full_strategy"),
             [],
             "orc",
             id="orc",
@@ -267,6 +246,7 @@ async def test_run_transfer_s3_to_postgres(
         pytest.param(
             ("parquet", {"compression": "gzip"}),
             "with_compression",
+            lf("full_strategy"),
             [],
             "gz.parquet",
             id="parquet",
@@ -274,6 +254,7 @@ async def test_run_transfer_s3_to_postgres(
         pytest.param(
             ("xml", {"compression": "none"}),
             "without_compression",
+            lf("full_strategy"),
             [],
             "xml",
             id="xml",
@@ -281,7 +262,7 @@ async def test_run_transfer_s3_to_postgres(
     ],
     indirect=["target_file_format", "file_format_flavor"],
 )
-async def test_run_transfer_postgres_to_s3(
+async def test_run_transfer_postgres_to_s3_with_full_strategy(
     group_owner: MockUser,
     init_df: DataFrame,
     client: AsyncClient,
@@ -292,62 +273,114 @@ async def test_run_transfer_postgres_to_s3(
     postgres_to_s3: Transfer,
     target_file_format,
     file_format_flavor: str,
+    strategy,
     transformations,
     expected_extension: str,
 ):
     format_name, format = target_file_format
-    source_path = f"/target/{format_name}/{file_format_flavor}"
-
-    # Arrange
+    target_path = f"/target/{format_name}/{file_format_flavor}"
     _, fill_with_data = prepare_postgres
     fill_with_data(init_df)
 
-    # Act
-    result = await client.post(
-        "v1/runs",
-        headers={"Authorization": f"Bearer {group_owner.token}"},
-        json={"transfer_id": postgres_to_s3.id},
-    )
-    # Assert
-    assert result.status_code == 200
+    await run_transfer_and_verify(client, group_owner, postgres_to_s3.id, auth=("basic", "s3"))
 
-    run_data = await get_run_on_end(
-        client=client,
-        run_id=result.json()["id"],
-        token=group_owner.token,
-    )
-    source_auth_data = run_data["transfer_dump"]["source_connection"]["auth_data"]
-    target_auth_data = run_data["transfer_dump"]["target_connection"]["auth_data"]
-
-    assert run_data["status"] == Status.FINISHED.value
-    assert source_auth_data["user"]
-    assert "password" not in source_auth_data
-    assert target_auth_data["access_key"]
-    assert "secret_key" not in target_auth_data
-
-    files = [os.fspath(file) for file in s3_file_connection.list_dir(source_path)]
-    for file_name in files:
-        run_created_at, index_and_extension = file_name.split("-")
-        assert len(run_created_at.split("_")) == 6, f"Got wrong {run_created_at=}"
-        assert index_and_extension.split(".", 1)[1] == expected_extension
+    files = [os.fspath(file) for file in s3_file_connection.list_dir(target_path)]
+    verify_file_name_template(files, expected_extension)
 
     reader = FileDFReader(
         connection=s3_file_df_connection,
         format=format,
-        source_path=source_path,
+        source_path=target_path,
         df_schema=init_df.schema,
         options={},
     )
     df = reader.run()
 
-    # as Excel does not support datetime values with precision greater than milliseconds
-    if format_name == "excel":
-        init_df = init_df.withColumn(
-            "REGISTERED_AT",
-            to_timestamp(date_format(col("REGISTERED_AT"), "yyyy-MM-dd HH:mm:ss.SSS")),
-        )
-
-    for field in init_df.schema:
-        df = df.withColumn(field.name, df[field.name].cast(field.dataType))
-
+    df, init_df = prepare_dataframes_for_comparison(
+        df,
+        init_df,
+        file_format=format_name,
+        transfer_direction="db_to_file",
+    )
     assert df.sort("id").collect() == init_df.sort("id").collect()
+
+
+@pytest.mark.parametrize(
+    "target_file_format, file_format_flavor, strategy, transformations, expected_extension",
+    [
+        pytest.param(
+            ("csv", {"compression": "lz4"}),
+            "with_compression",
+            lf("incremental_strategy_by_number_column"),
+            [],
+            "csv.lz4",
+            id="csv",
+        ),
+    ],
+    indirect=["target_file_format", "file_format_flavor"],
+)
+async def test_run_transfer_postgres_to_s3_with_incremental_strategy(
+    group_owner: MockUser,
+    init_df: DataFrame,
+    client: AsyncClient,
+    s3_file_df_connection: SparkS3,
+    s3_file_connection: S3,
+    prepare_postgres,
+    prepare_s3,
+    postgres_to_s3: Transfer,
+    target_file_format,
+    file_format_flavor: str,
+    strategy,
+    transformations,
+    expected_extension: str,
+):
+    format_name, format = target_file_format
+    target_path = f"/target/{format_name}/{file_format_flavor}"
+    _, fill_with_data = prepare_postgres
+
+    first_transfer_df, second_transfer_df = split_df(df=init_df, ratio=0.6, keep_sorted_by="number")
+    fill_with_data(first_transfer_df)
+    await run_transfer_and_verify(client, group_owner, postgres_to_s3.id, auth=("basic", "s3"))
+
+    files = [os.fspath(file) for file in s3_file_connection.list_dir(target_path)]
+    verify_file_name_template(files, expected_extension)
+
+    reader = FileDFReader(
+        connection=s3_file_df_connection,
+        format=format,
+        source_path=target_path,
+        df_schema=init_df.schema,
+        options={},
+    )
+    df = reader.run()
+
+    df, first_transfer_df = prepare_dataframes_for_comparison(
+        df,
+        first_transfer_df,
+        file_format=format_name,
+        transfer_direction="db_to_file",
+    )
+    assert df.sort("id").collect() == first_transfer_df.sort("id").collect()
+
+    fill_with_data(second_transfer_df)
+    await run_transfer_and_verify(client, group_owner, postgres_to_s3.id, auth=("basic", "s3"))
+
+    files = [os.fspath(file) for file in s3_file_connection.list_dir(target_path)]
+    verify_file_name_template(files, expected_extension)
+
+    reader = FileDFReader(
+        connection=s3_file_df_connection,
+        format=format,
+        source_path=target_path,
+        df_schema=init_df.schema,
+        options={},
+    )
+    df_with_increment = reader.run()
+
+    df_with_increment, init_df = prepare_dataframes_for_comparison(
+        df_with_increment,
+        init_df,
+        file_format=format_name,
+        transfer_direction="db_to_file",
+    )
+    assert df_with_increment.sort("id").collect() == init_df.sort("id").collect()

--- a/tests/test_integration/test_run_transfer/test_s3.py
+++ b/tests/test_integration/test_run_transfer/test_s3.py
@@ -368,15 +368,7 @@ async def test_run_transfer_postgres_to_s3_with_incremental_strategy(
     files = [os.fspath(file) for file in s3_file_connection.list_dir(target_path)]
     verify_file_name_template(files, expected_extension)
 
-    reader = FileDFReader(
-        connection=s3_file_df_connection,
-        format=format,
-        source_path=target_path,
-        df_schema=init_df.schema,
-        options={},
-    )
     df_with_increment = reader.run()
-
     df_with_increment, init_df = prepare_dataframes_for_comparison(
         df_with_increment,
         init_df,

--- a/tests/test_integration/test_run_transfer/test_samba.py
+++ b/tests/test_integration/test_run_transfer/test_samba.py
@@ -18,7 +18,7 @@ from tests.mocks import MockUser
 from tests.test_unit.utils import create_transfer
 from tests.utils import (
     add_increment_to_files_and_upload,
-    prepare_dataframes_for_comparison,
+    cast_dataframe_types,
     run_transfer_and_verify,
     split_df,
     verify_file_name_template,
@@ -145,12 +145,7 @@ async def test_run_transfer_samba_to_postgres_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(
-        df,
-        init_df,
-        file_format=file_format,
-        transfer_direction="file_to_db",
-    )
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
 
@@ -189,12 +184,7 @@ async def test_run_transfer_samba_to_postgres_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(
-        df,
-        init_df,
-        file_format=file_format,
-        transfer_direction="file_to_db",
-    )
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
     add_increment_to_files_and_upload(
@@ -206,12 +196,7 @@ async def test_run_transfer_samba_to_postgres_with_incremental_strategy(
     await run_transfer_and_verify(client, group_owner, samba_to_postgres.id)
 
     df_with_increment = reader.run()
-    df_with_increment, init_df = prepare_dataframes_for_comparison(
-        df_with_increment,
-        init_df,
-        file_format=file_format,
-        transfer_direction="file_to_db",
-    )
+    df_with_increment, init_df = cast_dataframe_types(df_with_increment, init_df)
     assert df_with_increment.sort("id").collect() == init_df.union(init_df).sort("id").collect()
 
 
@@ -266,12 +251,7 @@ async def test_run_transfer_postgres_to_samba_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(
-        df,
-        init_df,
-        file_format=format_name,
-        transfer_direction="db_to_file",
-    )
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
 
@@ -328,12 +308,7 @@ async def test_run_transfer_postgres_to_samba_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, first_transfer_df = prepare_dataframes_for_comparison(
-        df,
-        first_transfer_df,
-        file_format=format_name,
-        transfer_direction="db_to_file",
-    )
+    df, first_transfer_df = cast_dataframe_types(df, first_transfer_df)
     assert df.sort("id").collect() == first_transfer_df.sort("id").collect()
 
     fill_with_data(second_transfer_df)
@@ -343,10 +318,5 @@ async def test_run_transfer_postgres_to_samba_with_incremental_strategy(
     verify_file_name_template(os.listdir(tmp_path), expected_extension)
 
     df_with_increment = reader.run()
-    df_with_increment, second_transfer_df = prepare_dataframes_for_comparison(
-        df_with_increment,
-        second_transfer_df,
-        file_format=format_name,
-        transfer_direction="db_to_file",
-    )
+    df_with_increment, second_transfer_df = cast_dataframe_types(df_with_increment, second_transfer_df)
     assert df_with_increment.sort("id").collect() == init_df.sort("id").collect()

--- a/tests/test_integration/test_run_transfer/test_samba.py
+++ b/tests/test_integration/test_run_transfer/test_samba.py
@@ -12,15 +12,16 @@ from pyspark.sql import DataFrame
 from pytest_lazy_fixtures import lf
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from syncmaster.db.models import Connection, Group, Queue, Status
+from syncmaster.db.models import Connection, Group, Queue
 from syncmaster.db.models.transfer import Transfer
 from tests.mocks import MockUser
 from tests.test_unit.utils import create_transfer
 from tests.utils import (
     add_increment_to_files_and_upload,
-    get_run_on_end,
     prepare_dataframes_for_comparison,
     run_transfer_and_verify,
+    split_df,
+    verify_file_name_template,
 )
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.worker]
@@ -80,6 +81,7 @@ async def postgres_to_samba(
     postgres_connection: Connection,
     target_file_format,
     file_format_flavor: str,
+    strategy: dict,
 ):
     format_name, file_format = target_file_format
     result = await create_transfer(
@@ -102,6 +104,7 @@ async def postgres_to_samba(
             "file_name_template": "{run_created_at}-{index}.{extension}",
             "options": {},
         },
+        strategy_params=strategy,
         queue_id=queue.id,
     )
     yield result
@@ -142,7 +145,12 @@ async def test_run_transfer_samba_to_postgres_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(df, init_df, file_format)
+    df, init_df = prepare_dataframes_for_comparison(
+        df,
+        init_df,
+        file_format=file_format,
+        transfer_direction="file_to_db",
+    )
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
 
@@ -181,9 +189,13 @@ async def test_run_transfer_samba_to_postgres_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(df, init_df, file_format)
+    df, init_df = prepare_dataframes_for_comparison(
+        df,
+        init_df,
+        file_format=file_format,
+        transfer_direction="file_to_db",
+    )
     assert df.sort("id").collect() == init_df.sort("id").collect()
-    df_count = df.count()
 
     add_increment_to_files_and_upload(
         file_connection=samba_file_connection,
@@ -199,28 +211,34 @@ async def test_run_transfer_samba_to_postgres_with_incremental_strategy(
     )
     df_with_increment = reader.run()
 
-    df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df, file_format)
-    assert df_with_increment.count() > df_count
+    df_with_increment, init_df = prepare_dataframes_for_comparison(
+        df_with_increment,
+        init_df,
+        file_format=file_format,
+        transfer_direction="file_to_db",
+    )
     assert df_with_increment.sort("id").collect() == init_df.union(init_df).sort("id").collect()
 
 
 @pytest.mark.parametrize(
-    "target_file_format, file_format_flavor, expected_extension",
+    "target_file_format, file_format_flavor, expected_extension, strategy",
     [
         pytest.param(
             ("csv", {"compression": "lz4"}),
             "with_compression",
             "csv.lz4",
+            lf("full_strategy"),
             id="csv",
         ),
     ],
     indirect=["target_file_format", "file_format_flavor"],
 )
-async def test_run_transfer_postgres_to_samba(
+async def test_run_transfer_postgres_to_samba_with_full_strategy(
     group_owner: MockUser,
     init_df: DataFrame,
     client: AsyncClient,
     prepare_postgres,
+    samba_file_connection_with_path,
     samba_file_connection: Samba,
     samba_file_df_connection: SparkLocalFS,
     postgres_to_samba: Transfer,
@@ -228,35 +246,13 @@ async def test_run_transfer_postgres_to_samba(
     file_format_flavor: str,
     tmp_path: Path,
     expected_extension: str,
+    strategy: dict,
 ):
     format_name, format = target_file_format
-
-    # Arrange
     _, fill_with_data = prepare_postgres
     fill_with_data(init_df)
 
-    # Act
-    result = await client.post(
-        "v1/runs",
-        headers={"Authorization": f"Bearer {group_owner.token}"},
-        json={"transfer_id": postgres_to_samba.id},
-    )
-    # Assert
-    assert result.status_code == 200
-
-    run_data = await get_run_on_end(
-        client=client,
-        run_id=result.json()["id"],
-        token=group_owner.token,
-    )
-    source_auth_data = run_data["transfer_dump"]["source_connection"]["auth_data"]
-    target_auth_data = run_data["transfer_dump"]["target_connection"]["auth_data"]
-
-    assert run_data["status"] == Status.FINISHED.value
-    assert source_auth_data["user"]
-    assert "password" not in source_auth_data
-    assert target_auth_data["user"]
-    assert "password" not in target_auth_data
+    await run_transfer_and_verify(client, group_owner, postgres_to_samba.id)
 
     downloader = FileDownloader(
         connection=samba_file_connection,
@@ -265,11 +261,7 @@ async def test_run_transfer_postgres_to_samba(
     )
     downloader.run()
 
-    files = os.listdir(tmp_path)
-    for file_name in files:
-        run_created_at, index_and_extension = file_name.split("-")
-        assert len(run_created_at.split("_")) == 6, f"Got wrong {run_created_at=}"
-        assert index_and_extension.split(".", 1)[1] == expected_extension
+    verify_file_name_template(os.listdir(tmp_path), expected_extension)
 
     reader = FileDFReader(
         connection=samba_file_df_connection,
@@ -279,7 +271,100 @@ async def test_run_transfer_postgres_to_samba(
     )
     df = reader.run()
 
-    for field in init_df.schema:
-        df = df.withColumn(field.name, df[field.name].cast(field.dataType))
-
+    df, init_df = prepare_dataframes_for_comparison(
+        df,
+        init_df,
+        file_format=format_name,
+        transfer_direction="db_to_file",
+    )
     assert df.sort("id").collect() == init_df.sort("id").collect()
+
+
+@pytest.mark.parametrize(
+    "target_file_format, file_format_flavor, expected_extension, strategy",
+    [
+        pytest.param(
+            ("csv", {"compression": "lz4"}),
+            "with_compression",
+            "csv.lz4",
+            lf("incremental_strategy_by_number_column"),
+            id="csv",
+        ),
+    ],
+    indirect=["target_file_format", "file_format_flavor"],
+)
+async def test_run_transfer_postgres_to_samba_with_incremental_strategy(
+    group_owner: MockUser,
+    init_df: DataFrame,
+    client: AsyncClient,
+    prepare_postgres,
+    samba_file_connection_with_path,
+    samba_file_connection: Samba,
+    samba_file_df_connection: SparkLocalFS,
+    postgres_to_samba: Transfer,
+    target_file_format,
+    file_format_flavor: str,
+    tmp_path: Path,
+    expected_extension: str,
+    strategy: dict,
+):
+    format_name, format = target_file_format
+    _, fill_with_data = prepare_postgres
+
+    first_transfer_df, second_transfer_df = split_df(df=init_df, ratio=0.6, keep_sorted_by="number")
+    fill_with_data(first_transfer_df)
+
+    await run_transfer_and_verify(client, group_owner, postgres_to_samba.id)
+
+    downloader = FileDownloader(
+        connection=samba_file_connection,
+        source_path=f"/target/{format_name}/{file_format_flavor}",
+        local_path=tmp_path,
+    )
+    downloader.run()
+
+    verify_file_name_template(os.listdir(tmp_path), expected_extension)
+
+    reader = FileDFReader(
+        connection=samba_file_df_connection,
+        format=format,
+        source_path=tmp_path,
+        df_schema=init_df.schema,
+    )
+    df = reader.run()
+
+    df, first_transfer_df = prepare_dataframes_for_comparison(
+        df,
+        first_transfer_df,
+        file_format=format_name,
+        transfer_direction="db_to_file",
+    )
+    assert df.sort("id").collect() == first_transfer_df.sort("id").collect()
+
+    fill_with_data(second_transfer_df)
+    await run_transfer_and_verify(client, group_owner, postgres_to_samba.id)
+
+    downloader = FileDownloader(
+        connection=samba_file_connection,
+        source_path=f"/target/{format_name}/{file_format_flavor}",
+        local_path=tmp_path,
+    )
+    downloader.run()
+
+    verify_file_name_template(os.listdir(tmp_path), expected_extension)
+
+    reader = FileDFReader(
+        connection=samba_file_df_connection,
+        format=format,
+        source_path=tmp_path,
+        df_schema=init_df.schema,
+    )
+    df_with_increment = reader.run()
+
+    df_with_increment, second_transfer_df = prepare_dataframes_for_comparison(
+        df_with_increment,
+        second_transfer_df,
+        file_format=format_name,
+        transfer_direction="db_to_file",
+    )
+    assert df_with_increment.sort("id").collect() == init_df.sort("id").collect()

--- a/tests/test_integration/test_run_transfer/test_samba.py
+++ b/tests/test_integration/test_run_transfer/test_samba.py
@@ -205,12 +205,7 @@ async def test_run_transfer_samba_to_postgres_with_incremental_strategy(
 
     await run_transfer_and_verify(client, group_owner, samba_to_postgres.id)
 
-    reader = DBReader(
-        connection=postgres,
-        table="public.target_table",
-    )
     df_with_increment = reader.run()
-
     df_with_increment, init_df = prepare_dataframes_for_comparison(
         df_with_increment,
         init_df,
@@ -344,23 +339,10 @@ async def test_run_transfer_postgres_to_samba_with_incremental_strategy(
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, postgres_to_samba.id)
 
-    downloader = FileDownloader(
-        connection=samba_file_connection,
-        source_path=f"/target/{format_name}/{file_format_flavor}",
-        local_path=tmp_path,
-    )
     downloader.run()
-
     verify_file_name_template(os.listdir(tmp_path), expected_extension)
 
-    reader = FileDFReader(
-        connection=samba_file_df_connection,
-        format=format,
-        source_path=tmp_path,
-        df_schema=init_df.schema,
-    )
     df_with_increment = reader.run()
-
     df_with_increment, second_transfer_df = prepare_dataframes_for_comparison(
         df_with_increment,
         second_transfer_df,

--- a/tests/test_integration/test_run_transfer/test_sftp.py
+++ b/tests/test_integration/test_run_transfer/test_sftp.py
@@ -18,7 +18,7 @@ from tests.mocks import MockUser
 from tests.test_unit.utils import create_transfer
 from tests.utils import (
     add_increment_to_files_and_upload,
-    prepare_dataframes_for_comparison,
+    cast_dataframe_types,
     run_transfer_and_verify,
     split_df,
     verify_file_name_template,
@@ -149,12 +149,7 @@ async def test_run_transfer_sftp_to_postgres_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(
-        df,
-        init_df,
-        file_format=file_format,
-        transfer_direction="file_to_db",
-    )
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
 
@@ -195,12 +190,7 @@ async def test_run_transfer_sftp_to_postgres_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(
-        df,
-        init_df,
-        file_format=file_format,
-        transfer_direction="file_to_db",
-    )
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
     add_increment_to_files_and_upload(
@@ -212,12 +202,7 @@ async def test_run_transfer_sftp_to_postgres_with_incremental_strategy(
     await run_transfer_and_verify(client, group_owner, sftp_to_postgres.id)
 
     df_with_increment = reader.run()
-    df_with_increment, init_df = prepare_dataframes_for_comparison(
-        df_with_increment,
-        init_df,
-        file_format=file_format,
-        transfer_direction="file_to_db",
-    )
+    df_with_increment, init_df = cast_dataframe_types(df_with_increment, init_df)
     assert df_with_increment.sort("id").collect() == init_df.union(init_df).sort("id").collect()
 
 
@@ -272,12 +257,7 @@ async def test_run_transfer_postgres_to_sftp_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(
-        df,
-        init_df,
-        file_format=format_name,
-        transfer_direction="db_to_file",
-    )
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
 
@@ -334,12 +314,7 @@ async def test_run_transfer_postgres_to_sftp_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, first_transfer_df = prepare_dataframes_for_comparison(
-        df,
-        first_transfer_df,
-        file_format=format_name,
-        transfer_direction="db_to_file",
-    )
+    df, first_transfer_df = cast_dataframe_types(df, first_transfer_df)
     assert df.sort("id").collect() == first_transfer_df.sort("id").collect()
 
     fill_with_data(second_transfer_df)
@@ -349,10 +324,5 @@ async def test_run_transfer_postgres_to_sftp_with_incremental_strategy(
     verify_file_name_template(os.listdir(tmp_path), expected_extension)
 
     df_with_increment = reader.run()
-    df_with_increment, second_transfer_df = prepare_dataframes_for_comparison(
-        df_with_increment,
-        second_transfer_df,
-        file_format=format_name,
-        transfer_direction="db_to_file",
-    )
+    df_with_increment, second_transfer_df = cast_dataframe_types(df_with_increment, init_df)
     assert df_with_increment.sort("id").collect() == init_df.sort("id").collect()

--- a/tests/test_integration/test_run_transfer/test_sftp.py
+++ b/tests/test_integration/test_run_transfer/test_sftp.py
@@ -211,12 +211,7 @@ async def test_run_transfer_sftp_to_postgres_with_incremental_strategy(
 
     await run_transfer_and_verify(client, group_owner, sftp_to_postgres.id)
 
-    reader = DBReader(
-        connection=postgres,
-        table="public.target_table",
-    )
     df_with_increment = reader.run()
-
     df_with_increment, init_df = prepare_dataframes_for_comparison(
         df_with_increment,
         init_df,
@@ -350,23 +345,10 @@ async def test_run_transfer_postgres_to_sftp_with_incremental_strategy(
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, postgres_to_sftp.id)
 
-    downloader = FileDownloader(
-        connection=sftp_file_connection,
-        source_path=f"/config/target/{format_name}/{file_format_flavor}",
-        local_path=tmp_path,
-    )
     downloader.run()
-
     verify_file_name_template(os.listdir(tmp_path), expected_extension)
 
-    reader = FileDFReader(
-        connection=sftp_file_df_connection,
-        format=format,
-        source_path=tmp_path,
-        df_schema=init_df.schema,
-    )
     df_with_increment = reader.run()
-
     df_with_increment, second_transfer_df = prepare_dataframes_for_comparison(
         df_with_increment,
         second_transfer_df,

--- a/tests/test_integration/test_run_transfer/test_sftp.py
+++ b/tests/test_integration/test_run_transfer/test_sftp.py
@@ -12,15 +12,16 @@ from pyspark.sql import DataFrame
 from pytest_lazy_fixtures import lf
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from syncmaster.db.models import Connection, Group, Queue, Status
+from syncmaster.db.models import Connection, Group, Queue
 from syncmaster.db.models.transfer import Transfer
 from tests.mocks import MockUser
 from tests.test_unit.utils import create_transfer
 from tests.utils import (
     add_increment_to_files_and_upload,
-    get_run_on_end,
     prepare_dataframes_for_comparison,
     run_transfer_and_verify,
+    split_df,
+    verify_file_name_template,
 )
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.worker]
@@ -82,6 +83,7 @@ async def postgres_to_sftp(
     postgres_connection: Connection,
     target_file_format,
     file_format_flavor: str,
+    strategy: dict,
 ):
     format_name, file_format = target_file_format
     result = await create_transfer(
@@ -104,6 +106,7 @@ async def postgres_to_sftp(
             "file_name_template": "{run_created_at}-{index}.{extension}",
             "options": {},
         },
+        strategy_params=strategy,
         queue_id=queue.id,
     )
     yield result
@@ -146,7 +149,12 @@ async def test_run_transfer_sftp_to_postgres_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(df, init_df, file_format)
+    df, init_df = prepare_dataframes_for_comparison(
+        df,
+        init_df,
+        file_format=file_format,
+        transfer_direction="file_to_db",
+    )
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
 
@@ -187,9 +195,13 @@ async def test_run_transfer_sftp_to_postgres_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(df, init_df, file_format)
+    df, init_df = prepare_dataframes_for_comparison(
+        df,
+        init_df,
+        file_format=file_format,
+        transfer_direction="file_to_db",
+    )
     assert df.sort("id").collect() == init_df.sort("id").collect()
-    df_count = df.count()
 
     add_increment_to_files_and_upload(
         file_connection=sftp_file_connection,
@@ -205,28 +217,34 @@ async def test_run_transfer_sftp_to_postgres_with_incremental_strategy(
     )
     df_with_increment = reader.run()
 
-    df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df, file_format)
-    assert df_with_increment.count() > df_count
+    df_with_increment, init_df = prepare_dataframes_for_comparison(
+        df_with_increment,
+        init_df,
+        file_format=file_format,
+        transfer_direction="file_to_db",
+    )
     assert df_with_increment.sort("id").collect() == init_df.union(init_df).sort("id").collect()
 
 
 @pytest.mark.parametrize(
-    "target_file_format, file_format_flavor, expected_extension",
+    "target_file_format, file_format_flavor, expected_extension, strategy",
     [
         pytest.param(
             ("csv", {"compression": "lz4"}),
             "with_compression",
             "csv.lz4",
+            lf("full_strategy"),
             id="csv",
         ),
     ],
     indirect=["target_file_format", "file_format_flavor"],
 )
-async def test_run_transfer_postgres_to_sftp(
+async def test_run_transfer_postgres_to_sftp_with_full_strategy(
     group_owner: MockUser,
     init_df: DataFrame,
     client: AsyncClient,
     prepare_postgres,
+    sftp_file_connection_with_path,
     sftp_file_connection: SFTP,
     sftp_file_df_connection: SparkLocalFS,
     postgres_to_sftp: Transfer,
@@ -234,35 +252,13 @@ async def test_run_transfer_postgres_to_sftp(
     file_format_flavor: str,
     tmp_path: Path,
     expected_extension: str,
+    strategy: dict,
 ):
     format_name, format = target_file_format
-
-    # Arrange
     _, fill_with_data = prepare_postgres
     fill_with_data(init_df)
 
-    # Act
-    result = await client.post(
-        "v1/runs",
-        headers={"Authorization": f"Bearer {group_owner.token}"},
-        json={"transfer_id": postgres_to_sftp.id},
-    )
-    # Assert
-    assert result.status_code == 200
-
-    run_data = await get_run_on_end(
-        client=client,
-        run_id=result.json()["id"],
-        token=group_owner.token,
-    )
-    source_auth_data = run_data["transfer_dump"]["source_connection"]["auth_data"]
-    target_auth_data = run_data["transfer_dump"]["target_connection"]["auth_data"]
-
-    assert run_data["status"] == Status.FINISHED.value
-    assert source_auth_data["user"]
-    assert "password" not in source_auth_data
-    assert target_auth_data["user"]
-    assert "password" not in target_auth_data
+    await run_transfer_and_verify(client, group_owner, postgres_to_sftp.id)
 
     downloader = FileDownloader(
         connection=sftp_file_connection,
@@ -271,11 +267,7 @@ async def test_run_transfer_postgres_to_sftp(
     )
     downloader.run()
 
-    files = os.listdir(tmp_path)
-    for file_name in files:
-        run_created_at, index_and_extension = file_name.split("-")
-        assert len(run_created_at.split("_")) == 6, f"Got wrong {run_created_at=}"
-        assert index_and_extension.split(".", 1)[1] == expected_extension
+    verify_file_name_template(os.listdir(tmp_path), expected_extension)
 
     reader = FileDFReader(
         connection=sftp_file_df_connection,
@@ -285,7 +277,100 @@ async def test_run_transfer_postgres_to_sftp(
     )
     df = reader.run()
 
-    for field in init_df.schema:
-        df = df.withColumn(field.name, df[field.name].cast(field.dataType))
-
+    df, init_df = prepare_dataframes_for_comparison(
+        df,
+        init_df,
+        file_format=format_name,
+        transfer_direction="db_to_file",
+    )
     assert df.sort("id").collect() == init_df.sort("id").collect()
+
+
+@pytest.mark.parametrize(
+    "target_file_format, file_format_flavor, expected_extension, strategy",
+    [
+        pytest.param(
+            ("csv", {"compression": "lz4"}),
+            "with_compression",
+            "csv.lz4",
+            lf("incremental_strategy_by_number_column"),
+            id="csv",
+        ),
+    ],
+    indirect=["target_file_format", "file_format_flavor"],
+)
+async def test_run_transfer_postgres_to_sftp_with_incremental_strategy(
+    group_owner: MockUser,
+    init_df: DataFrame,
+    client: AsyncClient,
+    prepare_postgres,
+    sftp_file_connection_with_path,
+    sftp_file_connection: SFTP,
+    sftp_file_df_connection: SparkLocalFS,
+    postgres_to_sftp: Transfer,
+    target_file_format,
+    file_format_flavor: str,
+    tmp_path: Path,
+    expected_extension: str,
+    strategy: dict,
+):
+    format_name, format = target_file_format
+    _, fill_with_data = prepare_postgres
+
+    first_transfer_df, second_transfer_df = split_df(df=init_df, ratio=0.6, keep_sorted_by="number")
+    fill_with_data(first_transfer_df)
+
+    await run_transfer_and_verify(client, group_owner, postgres_to_sftp.id)
+
+    downloader = FileDownloader(
+        connection=sftp_file_connection,
+        source_path=f"/config/target/{format_name}/{file_format_flavor}",
+        local_path=tmp_path,
+    )
+    downloader.run()
+
+    verify_file_name_template(os.listdir(tmp_path), expected_extension)
+
+    reader = FileDFReader(
+        connection=sftp_file_df_connection,
+        format=format,
+        source_path=tmp_path,
+        df_schema=init_df.schema,
+    )
+    df = reader.run()
+
+    df, first_transfer_df = prepare_dataframes_for_comparison(
+        df,
+        first_transfer_df,
+        file_format=format_name,
+        transfer_direction="db_to_file",
+    )
+    assert df.sort("id").collect() == first_transfer_df.sort("id").collect()
+
+    fill_with_data(second_transfer_df)
+    await run_transfer_and_verify(client, group_owner, postgres_to_sftp.id)
+
+    downloader = FileDownloader(
+        connection=sftp_file_connection,
+        source_path=f"/config/target/{format_name}/{file_format_flavor}",
+        local_path=tmp_path,
+    )
+    downloader.run()
+
+    verify_file_name_template(os.listdir(tmp_path), expected_extension)
+
+    reader = FileDFReader(
+        connection=sftp_file_df_connection,
+        format=format,
+        source_path=tmp_path,
+        df_schema=init_df.schema,
+    )
+    df_with_increment = reader.run()
+
+    df_with_increment, second_transfer_df = prepare_dataframes_for_comparison(
+        df_with_increment,
+        second_transfer_df,
+        file_format=format_name,
+        transfer_direction="db_to_file",
+    )
+    assert df_with_increment.sort("id").collect() == init_df.sort("id").collect()

--- a/tests/test_integration/test_run_transfer/test_webdav.py
+++ b/tests/test_integration/test_run_transfer/test_webdav.py
@@ -205,12 +205,7 @@ async def test_run_transfer_webdav_to_postgres_with_incremental_strategy(
 
     await run_transfer_and_verify(client, group_owner, webdav_to_postgres.id)
 
-    reader = DBReader(
-        connection=postgres,
-        table="public.target_table",
-    )
     df_with_increment = reader.run()
-
     df_with_increment, init_df = prepare_dataframes_for_comparison(
         df_with_increment,
         init_df,
@@ -344,23 +339,10 @@ async def test_run_transfer_postgres_to_webdav_with_incremental_strategy(
     fill_with_data(second_transfer_df)
     await run_transfer_and_verify(client, group_owner, postgres_to_webdav.id)
 
-    downloader = FileDownloader(
-        connection=webdav_file_connection,
-        source_path=f"/target/{format_name}/{file_format_flavor}",
-        local_path=tmp_path,
-    )
     downloader.run()
-
     verify_file_name_template(os.listdir(tmp_path), expected_extension)
 
-    reader = FileDFReader(
-        connection=webdav_file_df_connection,
-        format=format,
-        source_path=tmp_path,
-        df_schema=init_df.schema,
-    )
     df_with_increment = reader.run()
-
     df_with_increment, second_transfer_df = prepare_dataframes_for_comparison(
         df_with_increment,
         second_transfer_df,

--- a/tests/test_integration/test_run_transfer/test_webdav.py
+++ b/tests/test_integration/test_run_transfer/test_webdav.py
@@ -12,15 +12,16 @@ from pyspark.sql import DataFrame
 from pytest_lazy_fixtures import lf
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from syncmaster.db.models import Connection, Group, Queue, Status
+from syncmaster.db.models import Connection, Group, Queue
 from syncmaster.db.models.transfer import Transfer
 from tests.mocks import MockUser
 from tests.test_unit.utils import create_transfer
 from tests.utils import (
     add_increment_to_files_and_upload,
-    get_run_on_end,
     prepare_dataframes_for_comparison,
     run_transfer_and_verify,
+    split_df,
+    verify_file_name_template,
 )
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.worker]
@@ -37,6 +38,7 @@ async def webdav_to_postgres(
     prepare_webdav,
     source_file_format,
     file_format_flavor: str,
+    strategy: dict,
 ):
     format_name, file_format = source_file_format
     format_name_in_path = "xlsx" if format_name == "excel" else format_name
@@ -62,10 +64,7 @@ async def webdav_to_postgres(
             "type": "postgres",
             "table_name": "public.target_table",
         },
-        strategy_params={
-            "type": "incremental",
-            "increment_by": "file_modified_since",
-        },
+        strategy_params=strategy,
         queue_id=queue.id,
     )
     yield result
@@ -82,6 +81,7 @@ async def postgres_to_webdav(
     postgres_connection: Connection,
     target_file_format,
     file_format_flavor: str,
+    strategy: dict,
 ):
     format_name, file_format = target_file_format
     result = await create_transfer(
@@ -104,6 +104,7 @@ async def postgres_to_webdav(
             "file_name_template": "{run_created_at}-{index}.{extension}",
             "options": {},
         },
+        strategy_params=strategy,
         queue_id=queue.id,
     )
     yield result
@@ -144,7 +145,12 @@ async def test_run_transfer_webdav_to_postgres_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(df, init_df, file_format)
+    df, init_df = prepare_dataframes_for_comparison(
+        df,
+        init_df,
+        file_format=file_format,
+        transfer_direction="file_to_db",
+    )
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
 
@@ -183,9 +189,13 @@ async def test_run_transfer_webdav_to_postgres_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(df, init_df, file_format)
+    df, init_df = prepare_dataframes_for_comparison(
+        df,
+        init_df,
+        file_format=file_format,
+        transfer_direction="file_to_db",
+    )
     assert df.sort("id").collect() == init_df.sort("id").collect()
-    df_count = df.count()
 
     add_increment_to_files_and_upload(
         file_connection=webdav_file_connection,
@@ -201,28 +211,34 @@ async def test_run_transfer_webdav_to_postgres_with_incremental_strategy(
     )
     df_with_increment = reader.run()
 
-    df_with_increment, init_df = prepare_dataframes_for_comparison(df_with_increment, init_df, file_format)
-    assert df_with_increment.count() > df_count
+    df_with_increment, init_df = prepare_dataframes_for_comparison(
+        df_with_increment,
+        init_df,
+        file_format=file_format,
+        transfer_direction="file_to_db",
+    )
     assert df_with_increment.sort("id").collect() == init_df.union(init_df).sort("id").collect()
 
 
 @pytest.mark.parametrize(
-    "target_file_format, file_format_flavor, expected_extension",
+    "target_file_format, file_format_flavor, expected_extension, strategy",
     [
         pytest.param(
             ("csv", {"compression": "lz4"}),
             "with_compression",
             "csv.lz4",
+            lf("full_strategy"),
             id="csv",
         ),
     ],
     indirect=["target_file_format", "file_format_flavor"],
 )
-async def test_run_transfer_postgres_to_webdav(
+async def test_run_transfer_postgres_to_webdav_with_full_strategy(
     group_owner: MockUser,
     init_df: DataFrame,
     client: AsyncClient,
     prepare_postgres,
+    webdav_file_connection_with_path,
     webdav_file_connection: WebDAV,
     webdav_file_df_connection: SparkLocalFS,
     postgres_to_webdav: Transfer,
@@ -230,35 +246,13 @@ async def test_run_transfer_postgres_to_webdav(
     file_format_flavor: str,
     tmp_path: Path,
     expected_extension: str,
+    strategy: dict,
 ):
     format_name, format = target_file_format
-
-    # Arrange
     _, fill_with_data = prepare_postgres
     fill_with_data(init_df)
 
-    # Act
-    result = await client.post(
-        "v1/runs",
-        headers={"Authorization": f"Bearer {group_owner.token}"},
-        json={"transfer_id": postgres_to_webdav.id},
-    )
-    # Assert
-    assert result.status_code == 200
-
-    run_data = await get_run_on_end(
-        client=client,
-        run_id=result.json()["id"],
-        token=group_owner.token,
-    )
-    source_auth_data = run_data["transfer_dump"]["source_connection"]["auth_data"]
-    target_auth_data = run_data["transfer_dump"]["target_connection"]["auth_data"]
-
-    assert run_data["status"] == Status.FINISHED.value
-    assert source_auth_data["user"]
-    assert "password" not in source_auth_data
-    assert target_auth_data["user"]
-    assert "password" not in target_auth_data
+    await run_transfer_and_verify(client, group_owner, postgres_to_webdav.id)
 
     downloader = FileDownloader(
         connection=webdav_file_connection,
@@ -267,11 +261,7 @@ async def test_run_transfer_postgres_to_webdav(
     )
     downloader.run()
 
-    files = os.listdir(tmp_path)
-    for file_name in files:
-        run_created_at, index_and_extension = file_name.split("-")
-        assert len(run_created_at.split("_")) == 6, f"Got wrong {run_created_at=}"
-        assert index_and_extension.split(".", 1)[1] == expected_extension
+    verify_file_name_template(os.listdir(tmp_path), expected_extension)
 
     reader = FileDFReader(
         connection=webdav_file_df_connection,
@@ -281,7 +271,100 @@ async def test_run_transfer_postgres_to_webdav(
     )
     df = reader.run()
 
-    for field in init_df.schema:
-        df = df.withColumn(field.name, df[field.name].cast(field.dataType))
-
+    df, init_df = prepare_dataframes_for_comparison(
+        df,
+        init_df,
+        file_format=format_name,
+        transfer_direction="db_to_file",
+    )
     assert df.sort("id").collect() == init_df.sort("id").collect()
+
+
+@pytest.mark.parametrize(
+    "target_file_format, file_format_flavor, expected_extension, strategy",
+    [
+        pytest.param(
+            ("csv", {"compression": "lz4"}),
+            "with_compression",
+            "csv.lz4",
+            lf("incremental_strategy_by_number_column"),
+            id="csv",
+        ),
+    ],
+    indirect=["target_file_format", "file_format_flavor"],
+)
+async def test_run_transfer_postgres_to_webdav_with_incremental_strategy(
+    group_owner: MockUser,
+    init_df: DataFrame,
+    client: AsyncClient,
+    prepare_postgres,
+    webdav_file_connection_with_path,
+    webdav_file_connection: WebDAV,
+    webdav_file_df_connection: SparkLocalFS,
+    postgres_to_webdav: Transfer,
+    target_file_format,
+    file_format_flavor: str,
+    tmp_path: Path,
+    expected_extension: str,
+    strategy: dict,
+):
+    format_name, format = target_file_format
+    _, fill_with_data = prepare_postgres
+
+    first_transfer_df, second_transfer_df = split_df(df=init_df, ratio=0.6, keep_sorted_by="number")
+    fill_with_data(first_transfer_df)
+
+    await run_transfer_and_verify(client, group_owner, postgres_to_webdav.id)
+
+    downloader = FileDownloader(
+        connection=webdav_file_connection,
+        source_path=f"/target/{format_name}/{file_format_flavor}",
+        local_path=tmp_path,
+    )
+    downloader.run()
+
+    verify_file_name_template(os.listdir(tmp_path), expected_extension)
+
+    reader = FileDFReader(
+        connection=webdav_file_df_connection,
+        format=format,
+        source_path=tmp_path,
+        df_schema=init_df.schema,
+    )
+    df = reader.run()
+
+    df, first_transfer_df = prepare_dataframes_for_comparison(
+        df,
+        first_transfer_df,
+        file_format=format_name,
+        transfer_direction="db_to_file",
+    )
+    assert df.sort("id").collect() == first_transfer_df.sort("id").collect()
+
+    fill_with_data(second_transfer_df)
+    await run_transfer_and_verify(client, group_owner, postgres_to_webdav.id)
+
+    downloader = FileDownloader(
+        connection=webdav_file_connection,
+        source_path=f"/target/{format_name}/{file_format_flavor}",
+        local_path=tmp_path,
+    )
+    downloader.run()
+
+    verify_file_name_template(os.listdir(tmp_path), expected_extension)
+
+    reader = FileDFReader(
+        connection=webdav_file_df_connection,
+        format=format,
+        source_path=tmp_path,
+        df_schema=init_df.schema,
+    )
+    df_with_increment = reader.run()
+
+    df_with_increment, second_transfer_df = prepare_dataframes_for_comparison(
+        df_with_increment,
+        second_transfer_df,
+        file_format=format_name,
+        transfer_direction="db_to_file",
+    )
+    assert df_with_increment.sort("id").collect() == init_df.sort("id").collect()

--- a/tests/test_integration/test_run_transfer/test_webdav.py
+++ b/tests/test_integration/test_run_transfer/test_webdav.py
@@ -18,7 +18,7 @@ from tests.mocks import MockUser
 from tests.test_unit.utils import create_transfer
 from tests.utils import (
     add_increment_to_files_and_upload,
-    prepare_dataframes_for_comparison,
+    cast_dataframe_types,
     run_transfer_and_verify,
     split_df,
     verify_file_name_template,
@@ -145,12 +145,7 @@ async def test_run_transfer_webdav_to_postgres_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(
-        df,
-        init_df,
-        file_format=file_format,
-        transfer_direction="file_to_db",
-    )
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
 
@@ -189,12 +184,7 @@ async def test_run_transfer_webdav_to_postgres_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(
-        df,
-        init_df,
-        file_format=file_format,
-        transfer_direction="file_to_db",
-    )
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
     add_increment_to_files_and_upload(
@@ -206,12 +196,7 @@ async def test_run_transfer_webdav_to_postgres_with_incremental_strategy(
     await run_transfer_and_verify(client, group_owner, webdav_to_postgres.id)
 
     df_with_increment = reader.run()
-    df_with_increment, init_df = prepare_dataframes_for_comparison(
-        df_with_increment,
-        init_df,
-        file_format=file_format,
-        transfer_direction="file_to_db",
-    )
+    df_with_increment, init_df = cast_dataframe_types(df_with_increment, init_df)
     assert df_with_increment.sort("id").collect() == init_df.union(init_df).sort("id").collect()
 
 
@@ -266,12 +251,7 @@ async def test_run_transfer_postgres_to_webdav_with_full_strategy(
     )
     df = reader.run()
 
-    df, init_df = prepare_dataframes_for_comparison(
-        df,
-        init_df,
-        file_format=format_name,
-        transfer_direction="db_to_file",
-    )
+    df, init_df = cast_dataframe_types(df, init_df)
     assert df.sort("id").collect() == init_df.sort("id").collect()
 
 
@@ -328,12 +308,7 @@ async def test_run_transfer_postgres_to_webdav_with_incremental_strategy(
     )
     df = reader.run()
 
-    df, first_transfer_df = prepare_dataframes_for_comparison(
-        df,
-        first_transfer_df,
-        file_format=format_name,
-        transfer_direction="db_to_file",
-    )
+    df, first_transfer_df = cast_dataframe_types(df, first_transfer_df)
     assert df.sort("id").collect() == first_transfer_df.sort("id").collect()
 
     fill_with_data(second_transfer_df)
@@ -343,10 +318,8 @@ async def test_run_transfer_postgres_to_webdav_with_incremental_strategy(
     verify_file_name_template(os.listdir(tmp_path), expected_extension)
 
     df_with_increment = reader.run()
-    df_with_increment, second_transfer_df = prepare_dataframes_for_comparison(
+    df_with_increment, second_transfer_df = cast_dataframe_types(
         df_with_increment,
         second_transfer_df,
-        file_format=format_name,
-        transfer_direction="db_to_file",
     )
     assert df_with_increment.sort("id").collect() == init_df.sort("id").collect()

--- a/tests/test_unit/test_auth/auth_fixtures/keycloak_fixture.py
+++ b/tests/test_unit/test_auth/auth_fixtures/keycloak_fixture.py
@@ -46,7 +46,7 @@ def get_public_key_pem(public_key):
 
 @pytest.fixture
 def create_session_cookie(rsa_keys, settings):
-    def _create_session_cookie(user, expire_in_msec=15000) -> str:
+    def _create_session_cookie(user, expire_in_msec=30000) -> str:
         private_pem = rsa_keys["private_pem"]
         session_secret_key = settings.server.session.secret_key
 

--- a/tests/test_unit/test_auth/auth_fixtures/keycloak_fixture.py
+++ b/tests/test_unit/test_auth/auth_fixtures/keycloak_fixture.py
@@ -46,7 +46,7 @@ def get_public_key_pem(public_key):
 
 @pytest.fixture
 def create_session_cookie(rsa_keys, settings):
-    def _create_session_cookie(user, expire_in_msec=30000) -> str:
+    def _create_session_cookie(user, expire_in_msec=60000) -> str:
         private_pem = rsa_keys["private_pem"]
         session_secret_key = settings.server.session.secret_key
 


### PR DESCRIPTION
## Change Summary
 
- Implemented `DBReader` for incremental transfer with `AutoDetectHWM`, using a unique name composed of `transfer.id`, `transfer.source_connection.type`, and `transfer.source_params.table_name`
- Before writing data to the target, added a check in `HWMStore` for existing HWM. If absent or `strategy=full`, writer is initialized with `if_exists="replace_overlapping_partitions"` for Hive and `if_exists="replace_entire_table"` for other databases. Otherwise, `if_exists="append"` is used to prevent duplicates
- Developed integration tests to verify incremental reading, first fetching all source data, then a new subset.

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.