### PR TITLE
[DOP-23976] Use PUT instead of PATCH for connections & transfers

### DIFF
--- a/docs/changelog/next_release/215.breaking.rst
+++ b/docs/changelog/next_release/215.breaking.rst
@@ -1,0 +1,1 @@
+Use PUT instead of PATCH for `Connection` and `Transfer` models

--- a/syncmaster/db/repositories/connection.py
+++ b/syncmaster/db/repositories/connection.py
@@ -89,21 +89,17 @@ class ConnectionRepository(RepositoryWithOwner[Connection]):
     async def update(
         self,
         connection_id: int,
-        name: str | None,
-        type: str | None,
-        description: str | None,
+        name: str,
+        type: str,
+        description: str,
         data: dict[str, Any],
     ) -> Connection:
         try:
-            connection = await self.read_by_id(connection_id=connection_id)
-            for key in connection.data:
-                data[key] = data.get(key, None) or connection.data[key]
-
             return await self._update(
                 Connection.id == connection_id,
-                type=type or connection.type,
-                name=name or connection.name,
-                description=description or connection.description,
+                type=type,
+                name=name,
+                description=description,
                 data=data,
             )
         except IntegrityError as e:

--- a/syncmaster/db/repositories/credentials_repository.py
+++ b/syncmaster/db/repositories/credentials_repository.py
@@ -71,10 +71,7 @@ class CredentialsRepository(Repository[AuthData]):
         connection_id: int,
         data: dict,
     ) -> AuthData:
-        creds = await self.read(connection_id)
         try:
-            for key in creds:
-                data[key] = data.get(key, None) or creds[key]
             return await self._update(
                 AuthData.connection_id == connection_id,
                 value=encrypt_auth_data(value=data, settings=self._settings),

--- a/syncmaster/db/repositories/transfer.py
+++ b/syncmaster/db/repositories/transfer.py
@@ -150,44 +150,35 @@ class TransferRepository(RepositoryWithOwner[Transfer]):
 
     async def update(
         self,
-        transfer: Transfer,
-        name: str | None,
-        description: str | None,
-        source_connection_id: int | None,
-        target_connection_id: int | None,
+        transfer_id: int,
+        name: str,
+        description: str,
+        source_connection_id: int,
+        target_connection_id: int,
         source_params: dict[str, Any],
         target_params: dict[str, Any],
         strategy_params: dict[str, Any],
         transformations: list[dict[str, Any]],
         resources: dict[str, Any],
-        is_scheduled: bool | None,
+        is_scheduled: bool,
         schedule: str | None,
-        new_queue_id: int | None,
+        queue_id: int,
     ) -> Transfer:
         try:
-            for old, new in [
-                (transfer.source_params, source_params),
-                (transfer.target_params, target_params),
-                (transfer.strategy_params, strategy_params),
-            ]:
-                for key in old:
-                    if key not in new or new[key] is None:
-                        new[key] = old[key]
-
             return await self._update(
-                Transfer.id == transfer.id,
-                name=name or transfer.name,
-                description=description or transfer.description,
+                Transfer.id == transfer_id,
+                name=name,
+                description=description,
                 strategy_params=strategy_params,
-                is_scheduled=is_scheduled if is_scheduled is not None else transfer.is_scheduled,
-                schedule=schedule or transfer.schedule,
-                source_connection_id=source_connection_id or transfer.source_connection_id,
-                target_connection_id=target_connection_id or transfer.target_connection_id,
+                is_scheduled=is_scheduled,
+                schedule=schedule or "",
+                source_connection_id=source_connection_id,
+                target_connection_id=target_connection_id,
                 source_params=source_params,
                 target_params=target_params,
-                transformations=transformations or transfer.transformations,
-                resources=resources or transfer.resources,
-                queue_id=new_queue_id or transfer.queue_id,
+                transformations=transformations,
+                resources=resources,
+                queue_id=queue_id,
             )
         except IntegrityError as e:
             self._raise_error(e)

--- a/syncmaster/exceptions/connection.py
+++ b/syncmaster/exceptions/connection.py
@@ -19,6 +19,10 @@ class ConnectionTypeUpdateError(SyncmasterError):
     pass
 
 
+class ConnectionAuthDataUpdateError(SyncmasterError):
+    pass
+
+
 class UserDoNotHaveRightsInTheTargetGroupError(SyncmasterError):
     pass
 

--- a/syncmaster/schemas/v1/__init__.py
+++ b/syncmaster/schemas/v1/__init__.py
@@ -28,7 +28,6 @@ from syncmaster.schemas.v1.transfers import (
     ReadFullTransferSchema,
     ReadTransferSchema,
     TransferPageSchema,
-    UpdateTransferSchema,
 )
 from syncmaster.schemas.v1.transfers.db import (
     HiveReadTransferSourceAndTarget,

--- a/syncmaster/schemas/v1/auth/basic.py
+++ b/syncmaster/schemas/v1/auth/basic.py
@@ -18,6 +18,9 @@ class ReadBasicAuthSchema(BasicAuthSchema):
     user: str
 
 
-class UpdateBasicAuthSchema(BasicAuthSchema):
-    user: str | None = None  # noqa: F722
+class UpdateBasicAuthSchema(CreateBasicAuthSchema):
     password: SecretStr | None = None
+
+    @property
+    def secret_field(self) -> str:
+        return "password"

--- a/syncmaster/schemas/v1/auth/s3.py
+++ b/syncmaster/schemas/v1/auth/s3.py
@@ -18,6 +18,9 @@ class ReadS3AuthSchema(S3AuthSchema):
     access_key: str
 
 
-class UpdateS3AuthSchema(S3AuthSchema):
-    access_key: str | None = None
+class UpdateS3AuthSchema(CreateS3AuthSchema):
     secret_key: SecretStr | None = None
+
+    @property
+    def secret_field(self) -> str:
+        return "secret_key"

--- a/syncmaster/schemas/v1/auth/samba.py
+++ b/syncmaster/schemas/v1/auth/samba.py
@@ -20,7 +20,9 @@ class ReadSambaAuthSchema(SambaAuthSchema):
     auth_type: Literal["NTLMv1", "NTLMv2"]
 
 
-class UpdateSambaAuthSchema(SambaAuthSchema):
-    user: str | None = None
+class UpdateSambaAuthSchema(CreateSambaAuthSchema):
     password: SecretStr | None = None
-    auth_type: Literal["NTLMv1", "NTLMv2"] | None = None
+
+    @property
+    def secret_field(self) -> str:
+        return "password"

--- a/syncmaster/schemas/v1/connections/clickhouse.py
+++ b/syncmaster/schemas/v1/connections/clickhouse.py
@@ -5,13 +5,12 @@ from pydantic import BaseModel, Field
 from syncmaster.schemas.v1.auth import (
     CreateBasicAuthSchema,
     ReadBasicAuthSchema,
-    UpdateBasicAuthSchema,
 )
+from syncmaster.schemas.v1.auth.basic import UpdateBasicAuthSchema
 from syncmaster.schemas.v1.connection_types import CLICKHOUSE_TYPE
 from syncmaster.schemas.v1.connections.connection_base import (
     CreateConnectionBaseSchema,
     ReadConnectionBaseSchema,
-    UpdateConnectionBaseSchema,
 )
 
 
@@ -27,13 +26,6 @@ class ReadClickhouseConnectionDataSchema(BaseModel):
     port: int
     database_name: str | None = None
     additional_params: dict = Field(default_factory=dict)
-
-
-class UpdateClickhouseConnectionDataSchema(BaseModel):
-    host: str | None = None
-    port: int | None = None
-    database_name: str | None = None
-    additional_params: dict | None = Field(default_factory=dict)
 
 
 class CreateClickhouseConnectionSchema(CreateConnectionBaseSchema):
@@ -56,7 +48,7 @@ class ReadClickhouseConnectionSchema(ReadConnectionBaseSchema):
     auth_data: ReadBasicAuthSchema | None = None
 
 
-class UpdateClickhouseConnectionSchema(UpdateConnectionBaseSchema):
-    type: CLICKHOUSE_TYPE
-    data: UpdateClickhouseConnectionDataSchema | None = Field(alias="connection_data", default=None)
-    auth_data: UpdateBasicAuthSchema | None = None
+class UpdateClickhouseConnectionSchema(CreateClickhouseConnectionSchema):
+    auth_data: UpdateBasicAuthSchema = Field(
+        description="Credentials for authorization",
+    )

--- a/syncmaster/schemas/v1/connections/connection_base.py
+++ b/syncmaster/schemas/v1/connections/connection_base.py
@@ -26,10 +26,5 @@ class ReadConnectionBaseSchema(BaseModel):
         populate_by_name = True
 
 
-class UpdateConnectionBaseSchema(BaseModel):
-    name: NameConstr | None = None  # noqa: F722
-    description: str | None = None
-
-
 class ReadAuthDataSchema(BaseModel):
     auth_data: ReadConnectionAuthDataSchema = Field(discriminator="type", default=...)

--- a/syncmaster/schemas/v1/connections/ftp.py
+++ b/syncmaster/schemas/v1/connections/ftp.py
@@ -6,13 +6,12 @@ from pydantic import BaseModel, Field
 from syncmaster.schemas.v1.auth import (
     CreateBasicAuthSchema,
     ReadBasicAuthSchema,
-    UpdateBasicAuthSchema,
 )
+from syncmaster.schemas.v1.auth.basic import UpdateBasicAuthSchema
 from syncmaster.schemas.v1.connection_types import FTP_TYPE
 from syncmaster.schemas.v1.connections.connection_base import (
     CreateConnectionBaseSchema,
     ReadConnectionBaseSchema,
-    UpdateConnectionBaseSchema,
 )
 
 
@@ -24,11 +23,6 @@ class CreateFTPConnectionDataSchema(BaseModel):
 class ReadFTPConnectionDataSchema(BaseModel):
     host: str
     port: int
-
-
-class UpdateFTPConnectionDataSchema(BaseModel):
-    host: str | None = None
-    port: int | None = None
 
 
 class CreateFTPConnectionSchema(CreateConnectionBaseSchema):
@@ -51,7 +45,7 @@ class ReadFTPConnectionSchema(ReadConnectionBaseSchema):
     auth_data: ReadBasicAuthSchema | None = None
 
 
-class UpdateFTPConnectionSchema(UpdateConnectionBaseSchema):
-    type: FTP_TYPE
-    data: UpdateFTPConnectionDataSchema | None = Field(alias="connection_data", default=None)
-    auth_data: UpdateBasicAuthSchema | None = None
+class UpdateFTPConnectionSchema(CreateFTPConnectionSchema):
+    auth_data: UpdateBasicAuthSchema = Field(
+        description="Credentials for authorization",
+    )

--- a/syncmaster/schemas/v1/connections/ftps.py
+++ b/syncmaster/schemas/v1/connections/ftps.py
@@ -6,13 +6,12 @@ from pydantic import BaseModel, Field
 from syncmaster.schemas.v1.auth import (
     CreateBasicAuthSchema,
     ReadBasicAuthSchema,
-    UpdateBasicAuthSchema,
 )
+from syncmaster.schemas.v1.auth.basic import UpdateBasicAuthSchema
 from syncmaster.schemas.v1.connection_types import FTPS_TYPE
 from syncmaster.schemas.v1.connections.connection_base import (
     CreateConnectionBaseSchema,
     ReadConnectionBaseSchema,
-    UpdateConnectionBaseSchema,
 )
 
 
@@ -24,11 +23,6 @@ class CreateFTPSConnectionDataSchema(BaseModel):
 class ReadFTPSConnectionDataSchema(BaseModel):
     host: str
     port: int
-
-
-class UpdateFTPSConnectionDataSchema(BaseModel):
-    host: str | None = None
-    port: int | None = None
 
 
 class CreateFTPSConnectionSchema(CreateConnectionBaseSchema):
@@ -51,7 +45,7 @@ class ReadFTPSConnectionSchema(ReadConnectionBaseSchema):
     auth_data: ReadBasicAuthSchema | None = None
 
 
-class UpdateFTPSConnectionSchema(UpdateConnectionBaseSchema):
-    type: FTPS_TYPE
-    data: UpdateFTPSConnectionDataSchema | None = Field(alias="connection_data", default=None)
-    auth_data: UpdateBasicAuthSchema | None = None
+class UpdateFTPSConnectionSchema(CreateFTPSConnectionSchema):
+    auth_data: UpdateBasicAuthSchema = Field(
+        description="Credentials for authorization",
+    )

--- a/syncmaster/schemas/v1/connections/hdfs.py
+++ b/syncmaster/schemas/v1/connections/hdfs.py
@@ -6,13 +6,12 @@ from pydantic import BaseModel, Field
 from syncmaster.schemas.v1.auth import (
     CreateBasicAuthSchema,
     ReadBasicAuthSchema,
-    UpdateBasicAuthSchema,
 )
+from syncmaster.schemas.v1.auth.basic import UpdateBasicAuthSchema
 from syncmaster.schemas.v1.connection_types import HDFS_TYPE
 from syncmaster.schemas.v1.connections.connection_base import (
     CreateConnectionBaseSchema,
     ReadConnectionBaseSchema,
-    UpdateConnectionBaseSchema,
 )
 
 
@@ -22,10 +21,6 @@ class CreateHDFSConnectionDataSchema(BaseModel):
 
 class ReadHDFSConnectionDataSchema(BaseModel):
     cluster: str
-
-
-class UpdateHDFSConnectionDataSchema(BaseModel):
-    cluster: str | None = None
 
 
 class CreateHDFSConnectionSchema(CreateConnectionBaseSchema):
@@ -48,7 +43,7 @@ class ReadHDFSConnectionSchema(ReadConnectionBaseSchema):
     auth_data: ReadBasicAuthSchema | None = None
 
 
-class UpdateHDFSConnectionSchema(UpdateConnectionBaseSchema):
-    type: HDFS_TYPE
-    data: UpdateHDFSConnectionDataSchema | None = Field(alias="connection_data", default=None)
-    auth_data: UpdateBasicAuthSchema | None = None
+class UpdateHDFSConnectionSchema(CreateHDFSConnectionSchema):
+    auth_data: UpdateBasicAuthSchema = Field(
+        description="Credentials for authorization",
+    )

--- a/syncmaster/schemas/v1/connections/hive.py
+++ b/syncmaster/schemas/v1/connections/hive.py
@@ -6,13 +6,12 @@ from pydantic import BaseModel, Field
 from syncmaster.schemas.v1.auth import (
     CreateBasicAuthSchema,
     ReadBasicAuthSchema,
-    UpdateBasicAuthSchema,
 )
+from syncmaster.schemas.v1.auth.basic import UpdateBasicAuthSchema
 from syncmaster.schemas.v1.connection_types import HIVE_TYPE
 from syncmaster.schemas.v1.connections.connection_base import (
     CreateConnectionBaseSchema,
     ReadConnectionBaseSchema,
-    UpdateConnectionBaseSchema,
 )
 
 
@@ -22,10 +21,6 @@ class CreateHiveConnectionDataSchema(BaseModel):
 
 class ReadHiveConnectionDataSchema(BaseModel):
     cluster: str
-
-
-class UpdateHiveConnectionDataSchema(BaseModel):
-    cluster: str | None = None
 
 
 class CreateHiveConnectionSchema(CreateConnectionBaseSchema):
@@ -48,7 +43,7 @@ class ReadHiveConnectionSchema(ReadConnectionBaseSchema):
     auth_data: ReadBasicAuthSchema | None = None
 
 
-class UpdateHiveConnectionSchema(UpdateConnectionBaseSchema):
-    type: HIVE_TYPE
-    data: UpdateHiveConnectionDataSchema | None = Field(alias="connection_data", default=None)
-    auth_data: UpdateBasicAuthSchema | None = None
+class UpdateHiveConnectionSchema(CreateHiveConnectionSchema):
+    auth_data: UpdateBasicAuthSchema = Field(
+        description="Credentials for authorization",
+    )

--- a/syncmaster/schemas/v1/connections/mssql.py
+++ b/syncmaster/schemas/v1/connections/mssql.py
@@ -5,13 +5,12 @@ from pydantic import BaseModel, Field
 from syncmaster.schemas.v1.auth import (
     CreateBasicAuthSchema,
     ReadBasicAuthSchema,
-    UpdateBasicAuthSchema,
 )
+from syncmaster.schemas.v1.auth.basic import UpdateBasicAuthSchema
 from syncmaster.schemas.v1.connection_types import MSSQL_TYPE
 from syncmaster.schemas.v1.connections.connection_base import (
     CreateConnectionBaseSchema,
     ReadConnectionBaseSchema,
-    UpdateConnectionBaseSchema,
 )
 
 
@@ -27,13 +26,6 @@ class ReadMSSQLConnectionDataSchema(BaseModel):
     port: int
     database_name: str
     additional_params: dict = Field(default_factory=dict)
-
-
-class UpdateMSSQLConnectionDataSchema(BaseModel):
-    host: str | None = None
-    port: int | None = None
-    database_name: str | None = None
-    additional_params: dict | None = Field(default_factory=dict)
 
 
 class CreateMSSQLConnectionSchema(CreateConnectionBaseSchema):
@@ -56,7 +48,7 @@ class ReadMSSQLConnectionSchema(ReadConnectionBaseSchema):
     auth_data: ReadBasicAuthSchema | None = None
 
 
-class UpdateMSSQLConnectionSchema(UpdateConnectionBaseSchema):
-    type: MSSQL_TYPE
-    data: UpdateMSSQLConnectionDataSchema | None = Field(alias="connection_data", default=None)
-    auth_data: UpdateBasicAuthSchema | None = None
+class UpdateMSSQLConnectionSchema(CreateMSSQLConnectionSchema):
+    auth_data: UpdateBasicAuthSchema = Field(
+        description="Credentials for authorization",
+    )

--- a/syncmaster/schemas/v1/connections/mysql.py
+++ b/syncmaster/schemas/v1/connections/mysql.py
@@ -5,13 +5,12 @@ from pydantic import BaseModel, Field
 from syncmaster.schemas.v1.auth import (
     CreateBasicAuthSchema,
     ReadBasicAuthSchema,
-    UpdateBasicAuthSchema,
 )
+from syncmaster.schemas.v1.auth.basic import UpdateBasicAuthSchema
 from syncmaster.schemas.v1.connection_types import MYSQL_TYPE
 from syncmaster.schemas.v1.connections.connection_base import (
     CreateConnectionBaseSchema,
     ReadConnectionBaseSchema,
-    UpdateConnectionBaseSchema,
 )
 
 
@@ -27,13 +26,6 @@ class ReadMySQLConnectionDataSchema(BaseModel):
     port: int
     database_name: str
     additional_params: dict = Field(default_factory=dict)
-
-
-class UpdateMySQLConnectionDataSchema(BaseModel):
-    host: str | None = None
-    port: int | None = None
-    database_name: str | None = None
-    additional_params: dict | None = Field(default_factory=dict)
 
 
 class CreateMySQLConnectionSchema(CreateConnectionBaseSchema):
@@ -56,7 +48,7 @@ class ReadMySQLConnectionSchema(ReadConnectionBaseSchema):
     auth_data: ReadBasicAuthSchema | None = None
 
 
-class UpdateMySQLConnectionSchema(UpdateConnectionBaseSchema):
-    type: MYSQL_TYPE
-    data: UpdateMySQLConnectionDataSchema | None = Field(alias="connection_data", default=None)
-    auth_data: UpdateBasicAuthSchema | None = None
+class UpdateMySQLConnectionSchema(CreateMySQLConnectionSchema):
+    auth_data: UpdateBasicAuthSchema = Field(
+        description="Credentials for authorization",
+    )

--- a/syncmaster/schemas/v1/connections/oracle.py
+++ b/syncmaster/schemas/v1/connections/oracle.py
@@ -6,13 +6,12 @@ from pydantic import BaseModel, Field, model_validator
 from syncmaster.schemas.v1.auth import (
     CreateBasicAuthSchema,
     ReadBasicAuthSchema,
-    UpdateBasicAuthSchema,
 )
+from syncmaster.schemas.v1.auth.basic import UpdateBasicAuthSchema
 from syncmaster.schemas.v1.connection_types import ORACLE_TYPE
 from syncmaster.schemas.v1.connections.connection_base import (
     CreateConnectionBaseSchema,
     ReadConnectionBaseSchema,
-    UpdateConnectionBaseSchema,
 )
 
 
@@ -39,21 +38,6 @@ class ReadOracleConnectionDataSchema(BaseModel):
     additional_params: dict = Field(default_factory=dict)
 
 
-class UpdateOracleConnectionDataSchema(BaseModel):
-    host: str | None = None
-    port: int | None = None
-    sid: str | None = None
-    service_name: str | None = None
-    additional_params: dict | None = Field(default_factory=dict)
-
-    @model_validator(mode="before")
-    def validate_connection_identifiers(cls, values):
-        sid, service_name = values.get("sid"), values.get("service_name")
-        if sid and service_name:
-            raise ValueError("You must specify either sid or service_name but not both")
-        return values
-
-
 class CreateOracleConnectionSchema(CreateConnectionBaseSchema):
     type: ORACLE_TYPE = Field(..., description="Connection type")
     data: CreateOracleConnectionDataSchema = Field(
@@ -74,7 +58,7 @@ class ReadOracleConnectionSchema(ReadConnectionBaseSchema):
     auth_data: ReadBasicAuthSchema | None = None
 
 
-class UpdateOracleConnectionSchema(UpdateConnectionBaseSchema):
-    type: ORACLE_TYPE
-    data: UpdateOracleConnectionDataSchema | None = Field(alias="connection_data", default=None)
-    auth_data: UpdateBasicAuthSchema | None = None
+class UpdateOracleConnectionSchema(CreateOracleConnectionSchema):
+    auth_data: UpdateBasicAuthSchema = Field(
+        description="Credentials for authorization",
+    )

--- a/syncmaster/schemas/v1/connections/postgres.py
+++ b/syncmaster/schemas/v1/connections/postgres.py
@@ -6,13 +6,12 @@ from pydantic import BaseModel, Field
 from syncmaster.schemas.v1.auth import (
     CreateBasicAuthSchema,
     ReadBasicAuthSchema,
-    UpdateBasicAuthSchema,
 )
+from syncmaster.schemas.v1.auth.basic import UpdateBasicAuthSchema
 from syncmaster.schemas.v1.connection_types import POSTGRES_TYPE
 from syncmaster.schemas.v1.connections.connection_base import (
     CreateConnectionBaseSchema,
     ReadConnectionBaseSchema,
-    UpdateConnectionBaseSchema,
 )
 
 
@@ -28,13 +27,6 @@ class ReadPostgresConnectionDataSchema(BaseModel):
     port: int = Field(gt=0, le=65535)
     database_name: str
     additional_params: dict = Field(default_factory=dict)
-
-
-class UpdatePostgresConnectionDataSchema(BaseModel):
-    host: str | None = None
-    port: int | None = None
-    database_name: str | None = None
-    additional_params: dict | None = Field(default_factory=dict)
 
 
 class CreatePostgresConnectionSchema(CreateConnectionBaseSchema):
@@ -57,7 +49,7 @@ class ReadPostgresConnectionSchema(ReadConnectionBaseSchema):
     auth_data: ReadBasicAuthSchema | None = None
 
 
-class UpdatePostgresConnectionSchema(UpdateConnectionBaseSchema):
-    type: POSTGRES_TYPE
-    data: UpdatePostgresConnectionDataSchema | None = Field(alias="connection_data", default=None)
-    auth_data: UpdateBasicAuthSchema | None = None
+class UpdatePostgresConnectionSchema(CreatePostgresConnectionSchema):
+    auth_data: UpdateBasicAuthSchema = Field(
+        description="Credentials for authorization",
+    )

--- a/syncmaster/schemas/v1/connections/s3.py
+++ b/syncmaster/schemas/v1/connections/s3.py
@@ -7,13 +7,12 @@ from pydantic import BaseModel, Field, model_validator
 from syncmaster.schemas.v1.auth import (
     CreateS3AuthSchema,
     ReadS3AuthSchema,
-    UpdateS3AuthSchema,
 )
+from syncmaster.schemas.v1.auth.s3 import UpdateS3AuthSchema
 from syncmaster.schemas.v1.connection_types import S3_TYPE
 from syncmaster.schemas.v1.connections.connection_base import (
     CreateConnectionBaseSchema,
     ReadConnectionBaseSchema,
-    UpdateConnectionBaseSchema,
 )
 
 
@@ -46,15 +45,6 @@ class ReadS3ConnectionDataSchema(BaseModel):
     bucket_style: Literal["domain", "path"] = "domain"
 
 
-class UpdateS3ConnectionDataSchema(BaseModel):
-    host: str | None = None
-    bucket: str | None = None
-    port: int | None = None
-    region: str | None = None
-    protocol: Literal["http", "https"] | None = None
-    bucket_style: Literal["domain", "path"] | None = None
-
-
 class CreateS3ConnectionSchema(CreateConnectionBaseSchema):
     type: S3_TYPE = Field(..., description="Connection type")
     data: CreateS3ConnectionDataSchema = Field(
@@ -77,7 +67,7 @@ class ReadS3ConnectionSchema(ReadConnectionBaseSchema):
     auth_data: ReadS3AuthSchema | None = Field(discriminator="type", default=None)
 
 
-class UpdateS3ConnectionSchema(UpdateConnectionBaseSchema):
-    type: S3_TYPE
-    data: UpdateS3ConnectionDataSchema | None = Field(alias="connection_data", default=None)
-    auth_data: UpdateS3AuthSchema | None = Field(discriminator="type", default=None)
+class UpdateS3ConnectionSchema(CreateS3ConnectionSchema):
+    auth_data: UpdateS3AuthSchema = Field(
+        description="Credentials for authorization",
+    )

--- a/syncmaster/schemas/v1/connections/samba.py
+++ b/syncmaster/schemas/v1/connections/samba.py
@@ -7,13 +7,12 @@ from pydantic import BaseModel, Field
 from syncmaster.schemas.v1.auth import (
     CreateSambaAuthSchema,
     ReadSambaAuthSchema,
-    UpdateSambaAuthSchema,
 )
+from syncmaster.schemas.v1.auth.samba import UpdateSambaAuthSchema
 from syncmaster.schemas.v1.connection_types import SAMBA_TYPE
 from syncmaster.schemas.v1.connections.connection_base import (
     CreateConnectionBaseSchema,
     ReadConnectionBaseSchema,
-    UpdateConnectionBaseSchema,
 )
 
 
@@ -31,14 +30,6 @@ class ReadSambaConnectionDataSchema(BaseModel):
     port: int | None
     protocol: Literal["SMB", "NetBIOS"]
     domain: str
-
-
-class UpdateSambaConnectionDataSchema(BaseModel):
-    host: str | None = None
-    share: str | None = None
-    port: int | None = None
-    protocol: Literal["SMB", "NetBIOS"] | None = None
-    domain: str | None = None
 
 
 class CreateSambaConnectionSchema(CreateConnectionBaseSchema):
@@ -61,7 +52,7 @@ class ReadSambaConnectionSchema(ReadConnectionBaseSchema):
     auth_data: ReadSambaAuthSchema | None = None
 
 
-class UpdateSambaConnectionSchema(UpdateConnectionBaseSchema):
-    type: SAMBA_TYPE
-    data: UpdateSambaConnectionDataSchema | None = Field(alias="connection_data", default=None)
-    auth_data: UpdateSambaAuthSchema | None = None
+class UpdateSambaConnectionSchema(CreateSambaConnectionSchema):
+    auth_data: UpdateSambaAuthSchema = Field(
+        description="Credentials for authorization",
+    )

--- a/syncmaster/schemas/v1/connections/sftp.py
+++ b/syncmaster/schemas/v1/connections/sftp.py
@@ -12,7 +12,6 @@ from syncmaster.schemas.v1.connection_types import SFTP_TYPE
 from syncmaster.schemas.v1.connections.connection_base import (
     CreateConnectionBaseSchema,
     ReadConnectionBaseSchema,
-    UpdateConnectionBaseSchema,
 )
 
 
@@ -24,11 +23,6 @@ class CreateSFTPConnectionDataSchema(BaseModel):
 class ReadSFTPConnectionDataSchema(BaseModel):
     host: str
     port: int
-
-
-class UpdateSFTPConnectionDataSchema(BaseModel):
-    host: str | None = None
-    port: int | None = None
 
 
 class CreateSFTPConnectionSchema(CreateConnectionBaseSchema):
@@ -51,7 +45,7 @@ class ReadSFTPConnectionSchema(ReadConnectionBaseSchema):
     auth_data: ReadBasicAuthSchema | None = None
 
 
-class UpdateSFTPConnectionSchema(UpdateConnectionBaseSchema):
-    type: SFTP_TYPE
-    data: UpdateSFTPConnectionDataSchema | None = Field(alias="connection_data", default=None)
-    auth_data: UpdateBasicAuthSchema | None = None
+class UpdateSFTPConnectionSchema(CreateSFTPConnectionSchema):
+    auth_data: UpdateBasicAuthSchema = Field(
+        description="Credentials for authorization",
+    )

--- a/syncmaster/schemas/v1/connections/webdav.py
+++ b/syncmaster/schemas/v1/connections/webdav.py
@@ -8,13 +8,12 @@ from pydantic import BaseModel, Field
 from syncmaster.schemas.v1.auth import (
     CreateBasicAuthSchema,
     ReadBasicAuthSchema,
-    UpdateBasicAuthSchema,
 )
+from syncmaster.schemas.v1.auth.basic import UpdateBasicAuthSchema
 from syncmaster.schemas.v1.connection_types import WEBDAV_TYPE
 from syncmaster.schemas.v1.connections.connection_base import (
     CreateConnectionBaseSchema,
     ReadConnectionBaseSchema,
-    UpdateConnectionBaseSchema,
 )
 
 
@@ -28,12 +27,6 @@ class ReadWebDAVConnectionDataSchema(BaseModel):
     host: str
     port: int | None
     protocol: Literal["http", "https"]
-
-
-class UpdateWebDAVConnectionDataSchema(BaseModel):
-    host: str | None = None
-    port: int | None = None
-    protocol: Literal["http", "https"] | None = None
 
 
 class CreateWebDAVConnectionSchema(CreateConnectionBaseSchema):
@@ -56,7 +49,7 @@ class ReadWebDAVConnectionSchema(ReadConnectionBaseSchema):
     auth_data: ReadBasicAuthSchema | None = None
 
 
-class UpdateWebDAVConnectionSchema(UpdateConnectionBaseSchema):
-    type: WEBDAV_TYPE
-    data: UpdateWebDAVConnectionDataSchema | None = Field(alias="connection_data", default=None)
-    auth_data: UpdateBasicAuthSchema | None = None
+class UpdateWebDAVConnectionSchema(CreateWebDAVConnectionSchema):
+    auth_data: UpdateBasicAuthSchema = Field(
+        description="Credentials for authorization",
+    )

--- a/syncmaster/schemas/v1/transfers/__init__.py
+++ b/syncmaster/schemas/v1/transfers/__init__.py
@@ -74,12 +74,12 @@ from syncmaster.schemas.v1.types import NameConstr
 
 ReadTransferSchemaSource = (
     PostgresReadTransferSourceAndTarget
-    | HDFSReadTransferSource
     | HiveReadTransferSourceAndTarget
     | OracleReadTransferSourceAndTarget
     | ClickhouseReadTransferSourceAndTarget
     | MSSQLReadTransferSourceAndTarget
     | MySQLReadTransferSourceAndTarget
+    | HDFSReadTransferSource
     | S3ReadTransferSource
     | SFTPReadTransferSource
     | FTPReadTransferSource
@@ -90,12 +90,12 @@ ReadTransferSchemaSource = (
 
 ReadTransferSchemaTarget = (
     PostgresReadTransferSourceAndTarget
-    | HDFSReadTransferTarget
     | HiveReadTransferSourceAndTarget
     | OracleReadTransferSourceAndTarget
     | ClickhouseReadTransferSourceAndTarget
     | MSSQLReadTransferSourceAndTarget
     | MySQLReadTransferSourceAndTarget
+    | HDFSReadTransferTarget
     | S3ReadTransferTarget
     | SFTPReadTransferTarget
     | FTPReadTransferTarget
@@ -106,12 +106,12 @@ ReadTransferSchemaTarget = (
 
 CreateTransferSchemaSource = (
     PostgresReadTransferSourceAndTarget
-    | HDFSCreateTransferSource
     | HiveReadTransferSourceAndTarget
     | OracleReadTransferSourceAndTarget
     | ClickhouseReadTransferSourceAndTarget
     | MSSQLReadTransferSourceAndTarget
     | MySQLReadTransferSourceAndTarget
+    | HDFSCreateTransferSource
     | S3CreateTransferSource
     | SFTPCreateTransferSource
     | FTPCreateTransferSource
@@ -122,52 +122,18 @@ CreateTransferSchemaSource = (
 
 CreateTransferSchemaTarget = (
     PostgresReadTransferSourceAndTarget
-    | HDFSCreateTransferTarget
     | HiveReadTransferSourceAndTarget
     | OracleReadTransferSourceAndTarget
     | ClickhouseReadTransferSourceAndTarget
     | MSSQLReadTransferSourceAndTarget
     | MySQLReadTransferSourceAndTarget
+    | HDFSCreateTransferTarget
     | S3CreateTransferTarget
     | SFTPCreateTransferTarget
     | FTPCreateTransferTarget
     | FTPSCreateTransferTarget
     | WebDAVCreateTransferTarget
     | SambaCreateTransferTarget
-)
-
-UpdateTransferSchemaSource = (
-    PostgresReadTransferSourceAndTarget
-    | HDFSReadTransferSource
-    | HiveReadTransferSourceAndTarget
-    | OracleReadTransferSourceAndTarget
-    | ClickhouseReadTransferSourceAndTarget
-    | MSSQLReadTransferSourceAndTarget
-    | MySQLReadTransferSourceAndTarget
-    | S3ReadTransferSource
-    | SFTPReadTransferSource
-    | FTPReadTransferSource
-    | FTPSReadTransferSource
-    | WebDAVReadTransferSource
-    | SambaReadTransferSource
-    | None
-)
-
-UpdateTransferSchemaTarget = (
-    PostgresReadTransferSourceAndTarget
-    | HDFSReadTransferSource
-    | HiveReadTransferSourceAndTarget
-    | OracleReadTransferSourceAndTarget
-    | ClickhouseReadTransferSourceAndTarget
-    | MSSQLReadTransferSourceAndTarget
-    | MySQLReadTransferSourceAndTarget
-    | S3ReadTransferTarget
-    | SFTPReadTransferTarget
-    | FTPReadTransferTarget
-    | FTPSReadTransferTarget
-    | WebDAVReadTransferTarget
-    | SambaReadTransferTarget
-    | None
 )
 
 TransformationSchema = DataframeRowsFilter | DataframeColumnsFilter | FileMetadataFilter
@@ -277,21 +243,6 @@ class CreateTransferSchema(BaseModel):
             raise ValueError("S3 and HDFS sources do not support incremental strategy for now")
 
         return values
-
-
-class UpdateTransferSchema(BaseModel):
-    source_connection_id: int | None = None
-    target_connection_id: int | None = None
-    name: NameConstr | None = None  # noqa: F722
-    description: str | None = None
-    is_scheduled: bool | None = None
-    schedule: str | None = None
-    new_queue_id: int | None = None
-    source_params: UpdateTransferSchemaSource = Field(discriminator="type", default=None)
-    target_params: UpdateTransferSchemaTarget = Field(discriminator="type", default=None)
-    strategy_params: FullStrategy | IncrementalStrategy | None = Field(discriminator="type", default=None)
-    transformations: list[Annotated[TransformationSchema, Field(discriminator="type", default=None)]] = None
-    resources: Resources | None = Field(default=None)
 
 
 class ReadFullTransferSchema(ReadTransferSchema):

--- a/syncmaster/server/handler.py
+++ b/syncmaster/server/handler.py
@@ -13,6 +13,7 @@ from syncmaster.errors.registration import get_response_for_exception
 from syncmaster.exceptions import ActionNotAllowedError, SyncmasterError
 from syncmaster.exceptions.auth import AuthorizationError
 from syncmaster.exceptions.connection import (
+    ConnectionAuthDataUpdateError,
     ConnectionDeleteError,
     ConnectionNotFoundError,
     ConnectionOwnerError,
@@ -252,6 +253,14 @@ async def syncmsater_exception_handler(request: Request, exc: SyncmasterError):
     if isinstance(exc, ConnectionTypeUpdateError):
         content.code = "conflict"
         content.message = "You cannot update the connection type of a connection already associated with a transfer."
+        return exception_json_response(
+            status=status.HTTP_409_CONFLICT,
+            content=content,
+        )
+
+    if isinstance(exc, ConnectionAuthDataUpdateError):
+        content.code = "conflict"
+        content.message = "You cannot update the connection auth type without providing a new secret value."
         return exception_json_response(
             status=status.HTTP_409_CONFLICT,
             content=content,

--- a/tests/test_unit/test_connections/test_db_connection/test_update_mssql_connection.py
+++ b/tests/test_unit/test_connections/test_db_connection/test_update_mssql_connection.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import AsyncClient
 
 from tests.mocks import MockConnection, UserTestRoles
+from tests.test_unit.utils import fetch_connection_json
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.server, pytest.mark.mssql]
 
@@ -30,28 +31,28 @@ async def test_developer_plus_can_update_mssql_connection(
     group_connection: MockConnection,
     role_developer_plus: UserTestRoles,
 ):
-    # Arrange
     user = group_connection.owner_group.get_member_of_role(role_developer_plus)
-    group_connection.connection.group.id
+    connection_json = await fetch_connection_json(client, user.token, group_connection)
 
-    # Act
-    result = await client.patch(
+    result = await client.put(
         f"v1/connections/{group_connection.id}",
         headers={"Authorization": f"Bearer {user.token}"},
         json={
+            **connection_json,
             "type": "mssql",
             "connection_data": {
                 "host": "127.0.1.1",
+                "port": 1434,
                 "database_name": "new_name",
             },
             "auth_data": {
                 "type": "basic",
                 "user": "new_user",
+                "password": "new_password",
             },
         },
     )
 
-    # Assert
     assert result.status_code == 200
     assert result.json() == {
         "id": group_connection.id,
@@ -61,7 +62,7 @@ async def test_developer_plus_can_update_mssql_connection(
         "type": "mssql",
         "connection_data": {
             "host": "127.0.1.1",
-            "port": group_connection.data["port"],
+            "port": 1434,
             "database_name": "new_name",
             "additional_params": {},
         },

--- a/tests/test_unit/test_connections/test_db_connection/test_update_mysql_connection.py
+++ b/tests/test_unit/test_connections/test_db_connection/test_update_mysql_connection.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import AsyncClient
 
 from tests.mocks import MockConnection, UserTestRoles
+from tests.test_unit.utils import fetch_connection_json
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.server, pytest.mark.mysql]
 
@@ -30,28 +31,28 @@ async def test_developer_plus_can_update_mysql_connection(
     group_connection: MockConnection,
     role_developer_plus: UserTestRoles,
 ):
-    # Arrange
     user = group_connection.owner_group.get_member_of_role(role_developer_plus)
-    group_connection.connection.group.id
+    connection_json = await fetch_connection_json(client, user.token, group_connection)
 
-    # Act
-    result = await client.patch(
+    result = await client.put(
         f"v1/connections/{group_connection.id}",
         headers={"Authorization": f"Bearer {user.token}"},
         json={
+            **connection_json,
             "type": group_connection.type,
             "connection_data": {
                 "host": "127.0.1.1",
+                "port": 3307,
                 "database_name": "new_database",
             },
             "auth_data": {
                 "type": "basic",
                 "user": "new_user",
+                "password": "new_password",
             },
         },
     )
 
-    # Assert
     assert result.status_code == 200
     assert result.json() == {
         "id": group_connection.id,
@@ -61,7 +62,7 @@ async def test_developer_plus_can_update_mysql_connection(
         "type": "mysql",
         "connection_data": {
             "host": "127.0.1.1",
-            "port": group_connection.data["port"],
+            "port": 3307,
             "database_name": "new_database",
             "additional_params": {},
         },

--- a/tests/test_unit/test_connections/test_file_connection/test_update_ftp_connection.py
+++ b/tests/test_unit/test_connections/test_file_connection/test_update_ftp_connection.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import AsyncClient
 
 from tests.mocks import MockConnection, UserTestRoles
+from tests.test_unit.utils import fetch_connection_json
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.server, pytest.mark.ftp]
 
@@ -31,24 +32,23 @@ async def test_developer_plus_can_update_ftp_connection(
     create_connection_data: dict,
     create_connection_auth_data: dict,
 ):
-    # Arrange
     user = group_connection.owner_group.get_member_of_role(role_developer_plus)
+    new_connection_data = {"host": "new_host", "port": 81}
+    connection_json = await fetch_connection_json(client, user.token, group_connection)
 
-    # Act
-    result = await client.patch(
+    result = await client.put(
         f"v1/connections/{group_connection.id}",
         headers={"Authorization": f"Bearer {user.token}"},
-        json={"type": "ftp", "connection_data": {"host": "new_host"}},
+        json={**connection_json, "type": "ftp", "connection_data": new_connection_data},
     )
 
-    # Assert
     assert result.json() == {
         "id": group_connection.id,
         "name": group_connection.connection.name,
         "description": group_connection.description,
         "type": group_connection.type,
         "group_id": group_connection.group_id,
-        "connection_data": {"host": "new_host", "port": 80},
+        "connection_data": new_connection_data,
         "auth_data": {
             "type": group_connection.credentials.value["type"],
             "user": group_connection.credentials.value["user"],

--- a/tests/test_unit/test_connections/test_file_connection/test_update_ftps_connection.py
+++ b/tests/test_unit/test_connections/test_file_connection/test_update_ftps_connection.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import AsyncClient
 
 from tests.mocks import MockConnection, UserTestRoles
+from tests.test_unit.utils import fetch_connection_json
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.server, pytest.mark.ftps]
 
@@ -31,24 +32,23 @@ async def test_developer_plus_can_update_ftps_connection(
     create_connection_data: dict,
     create_connection_auth_data: dict,
 ):
-    # Arrange
     user = group_connection.owner_group.get_member_of_role(role_developer_plus)
+    new_connection_data = {"host": "new_host", "port": 81}
+    connection_json = await fetch_connection_json(client, user.token, group_connection)
 
-    # Act
-    result = await client.patch(
+    result = await client.put(
         f"v1/connections/{group_connection.id}",
         headers={"Authorization": f"Bearer {user.token}"},
-        json={"type": "ftps", "connection_data": {"host": "new_host"}},
+        json={**connection_json, "type": "ftps", "connection_data": new_connection_data},
     )
 
-    # Assert
     assert result.json() == {
         "id": group_connection.id,
         "name": group_connection.connection.name,
         "description": group_connection.description,
         "type": group_connection.type,
         "group_id": group_connection.group_id,
-        "connection_data": {"host": "new_host", "port": 80},
+        "connection_data": new_connection_data,
         "auth_data": {
             "type": group_connection.credentials.value["type"],
             "user": group_connection.credentials.value["user"],

--- a/tests/test_unit/test_connections/test_file_connection/test_update_s3_connection.py
+++ b/tests/test_unit/test_connections/test_file_connection/test_update_s3_connection.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import AsyncClient
 
 from tests.mocks import MockConnection, UserTestRoles
+from tests.test_unit.utils import fetch_connection_json
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.server, pytest.mark.s3]
 
@@ -33,33 +34,30 @@ async def test_developer_plus_can_update_s3_connection(
     group_connection: MockConnection,
     role_developer_plus: UserTestRoles,
 ):
-    # Arrange
     user = group_connection.owner_group.get_member_of_role(role_developer_plus)
-    parameter_to_update = "region"
-    value_to_update = "new_region"
+    connection_json = await fetch_connection_json(client, user.token, group_connection)
+    new_connection_data = {
+        "bucket": "new_bucket",
+        "host": "new_host",
+        "port": 80,
+        "region": "new_region",
+        "protocol": "http",
+        "bucket_style": "domain",
+    }
 
-    # Act
-    result = await client.patch(
+    result = await client.put(
         f"v1/connections/{group_connection.id}",
         headers={"Authorization": f"Bearer {user.token}"},
-        json={"type": "s3", "connection_data": {parameter_to_update: value_to_update}},
+        json={**connection_json, "type": "s3", "connection_data": new_connection_data},
     )
 
-    # Assert
     assert result.json() == {
         "id": group_connection.id,
         "name": group_connection.connection.name,
         "description": group_connection.description,
         "group_id": group_connection.group_id,
         "type": group_connection.type,
-        "connection_data": {
-            parameter_to_update: value_to_update,
-            "host": group_connection.data["host"],
-            "bucket": group_connection.data["bucket"],
-            "port": group_connection.data["port"],
-            "protocol": group_connection.data["protocol"],
-            "bucket_style": group_connection.data["bucket_style"],
-        },
+        "connection_data": new_connection_data,
         "auth_data": {
             "type": group_connection.credentials.value["type"],
             "access_key": group_connection.credentials.value["access_key"],

--- a/tests/test_unit/test_connections/test_file_connection/test_update_samba_connection.py
+++ b/tests/test_unit/test_connections/test_file_connection/test_update_samba_connection.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import AsyncClient
 
 from tests.mocks import MockConnection, UserTestRoles
+from tests.test_unit.utils import fetch_connection_json
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.server, pytest.mark.samba]
 
@@ -16,6 +17,7 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.server, pytest.mark.samba]
                 "share": "some_folder",
                 "protocol": "NetBIOS",
                 "domain": "domain",
+                "port": None,
             },
             {
                 "type": "samba",
@@ -34,30 +36,29 @@ async def test_developer_plus_can_update_samba_connection(
     create_connection_data: dict,
     create_connection_auth_data: dict,
 ):
-    # Arrange
     user = group_connection.owner_group.get_member_of_role(role_developer_plus)
+    connection_json = await fetch_connection_json(client, user.token, group_connection)
+    new_connection_data = {
+        "host": "new_host",
+        "share": "new_folder",
+        "protocol": "NetBIOS",
+        "domain": "domain",
+        "port": None,
+    }
 
-    # Act
-    result = await client.patch(
+    result = await client.put(
         f"v1/connections/{group_connection.id}",
         headers={"Authorization": f"Bearer {user.token}"},
-        json={"type": "samba", "connection_data": {"host": "new_host"}},
+        json={**connection_json, "type": "samba", "connection_data": new_connection_data},
     )
 
-    # Assert
     assert result.json() == {
         "id": group_connection.id,
         "name": group_connection.connection.name,
         "description": group_connection.description,
         "type": group_connection.type,
         "group_id": group_connection.group_id,
-        "connection_data": {
-            "host": "new_host",
-            "share": "some_folder",
-            "protocol": "NetBIOS",
-            "domain": "domain",
-            "port": None,
-        },
+        "connection_data": new_connection_data,
         "auth_data": {
             "type": group_connection.credentials.value["type"],
             "user": group_connection.credentials.value["user"],

--- a/tests/test_unit/test_connections/test_file_connection/test_update_sftp_connection.py
+++ b/tests/test_unit/test_connections/test_file_connection/test_update_sftp_connection.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import AsyncClient
 
 from tests.mocks import MockConnection, UserTestRoles
+from tests.test_unit.utils import fetch_connection_json
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.server, pytest.mark.sftp]
 
@@ -31,24 +32,23 @@ async def test_developer_plus_can_update_sftp_connection(
     create_connection_data: dict,
     create_connection_auth_data: dict,
 ):
-    # Arrange
     user = group_connection.owner_group.get_member_of_role(role_developer_plus)
+    new_connection_data = {"host": "new_host", "port": 81}
+    connection_json = await fetch_connection_json(client, user.token, group_connection)
 
-    # Act
-    result = await client.patch(
+    result = await client.put(
         f"v1/connections/{group_connection.id}",
         headers={"Authorization": f"Bearer {user.token}"},
-        json={"type": "sftp", "connection_data": {"host": "new_host"}},
+        json={**connection_json, "type": "sftp", "connection_data": new_connection_data},
     )
 
-    # Assert
     assert result.json() == {
         "id": group_connection.id,
         "name": group_connection.connection.name,
         "description": group_connection.description,
         "type": group_connection.type,
         "group_id": group_connection.group_id,
-        "connection_data": {"host": "new_host", "port": 80},
+        "connection_data": new_connection_data,
         "auth_data": {
             "type": group_connection.credentials.value["type"],
             "user": group_connection.credentials.value["user"],

--- a/tests/test_unit/test_connections/test_file_connection/test_update_webdav_connection.py
+++ b/tests/test_unit/test_connections/test_file_connection/test_update_webdav_connection.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import AsyncClient
 
 from tests.mocks import MockConnection, UserTestRoles
+from tests.test_unit.utils import fetch_connection_json
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.server, pytest.mark.webdav]
 
@@ -32,24 +33,23 @@ async def test_developer_plus_can_update_webdav_connection(
     create_connection_data: dict,
     create_connection_auth_data: dict,
 ):
-    # Arrange
     user = group_connection.owner_group.get_member_of_role(role_developer_plus)
+    new_connection_data = {"host": "new_host", "port": 443, "protocol": "https"}
+    connection_json = await fetch_connection_json(client, user.token, group_connection)
 
-    # Act
-    result = await client.patch(
+    result = await client.put(
         f"v1/connections/{group_connection.id}",
         headers={"Authorization": f"Bearer {user.token}"},
-        json={"type": "webdav", "connection_data": {"host": "new_host"}},
+        json={**connection_json, "type": "webdav", "connection_data": new_connection_data},
     )
 
-    # Assert
     assert result.json() == {
         "id": group_connection.id,
         "name": group_connection.connection.name,
         "description": group_connection.description,
         "type": group_connection.type,
         "group_id": group_connection.group_id,
-        "connection_data": {"host": "new_host", "port": 443, "protocol": "https"},
+        "connection_data": new_connection_data,
         "auth_data": {
             "type": group_connection.credentials.value["type"],
             "user": group_connection.credentials.value["user"],

--- a/tests/test_unit/test_transfers/test_create_transfer.py
+++ b/tests/test_unit/test_transfers/test_create_transfer.py
@@ -515,12 +515,12 @@ async def test_superuser_can_create_transfer(
                             "location": ["body", "source_params"],
                             "message": (
                                 "Input tag 'new some connection type' found using 'type' "
-                                "does not match any of the expected tags: 'postgres', 'hdfs', 'hive', 'oracle', 'clickhouse', 'mssql', 'mysql', 's3', 'sftp', 'ftp', 'ftps', 'webdav', 'samba'"
+                                "does not match any of the expected tags: 'postgres', 'hive', 'oracle', 'clickhouse', 'mssql', 'mysql', 'hdfs', 's3', 'sftp', 'ftp', 'ftps', 'webdav', 'samba'"
                             ),
                             "code": "union_tag_invalid",
                             "context": {
                                 "discriminator": "'type'",
-                                "expected_tags": "'postgres', 'hdfs', 'hive', 'oracle', 'clickhouse', 'mssql', 'mysql', 's3', 'sftp', 'ftp', 'ftps', 'webdav', 'samba'",
+                                "expected_tags": "'postgres', 'hive', 'oracle', 'clickhouse', 'mssql', 'mysql', 'hdfs', 's3', 'sftp', 'ftp', 'ftps', 'webdav', 'samba'",
                                 "tag": "new some connection type",
                             },
                             "input": {

--- a/tests/test_unit/test_transfers/test_file_transfers/test_read_transfer.py
+++ b/tests/test_unit/test_transfers/test_file_transfers/test_read_transfer.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import AsyncClient
 
 from tests.mocks import MockTransfer, UserTestRoles
+from tests.test_unit.utils import build_transfer_json
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.server]
 
@@ -129,29 +130,12 @@ async def test_guest_plus_can_read_s3_transfer(
     create_connection_data: dict,
     create_transfer_data: dict,
 ):
-    # Arrange
     user = group_transfer.owner_group.get_member_of_role(role_guest_plus)
 
-    # Act
     result = await client.get(
         f"v1/transfers/{group_transfer.id}",
         headers={"Authorization": f"Bearer {user.token}"},
     )
-    # Assert
-    assert result.json() == {
-        "id": group_transfer.id,
-        "group_id": group_transfer.group_id,
-        "name": group_transfer.name,
-        "description": group_transfer.description,
-        "schedule": group_transfer.schedule,
-        "is_scheduled": group_transfer.is_scheduled,
-        "source_connection_id": group_transfer.source_connection_id,
-        "target_connection_id": group_transfer.target_connection_id,
-        "source_params": group_transfer.source_params,
-        "target_params": group_transfer.target_params,
-        "strategy_params": group_transfer.strategy_params,
-        "transformations": group_transfer.transformations,
-        "resources": group_transfer.resources,
-        "queue_id": group_transfer.transfer.queue_id,
-    }
+
+    assert result.json() == build_transfer_json(group_transfer)
     assert result.status_code == 200

--- a/tests/test_unit/test_transfers/test_update_transfer.py
+++ b/tests/test_unit/test_transfers/test_update_transfer.py
@@ -3,6 +3,7 @@ from httpx import AsyncClient
 
 from syncmaster.db.models import Queue
 from tests.mocks import MockConnection, MockGroup, MockTransfer, MockUser, UserTestRoles
+from tests.test_unit.utils import build_transfer_json, fetch_transfer_json
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.server]
 
@@ -12,8 +13,8 @@ async def test_developer_plus_can_update_transfer(
     group_transfer: MockTransfer,
     role_developer_plus: UserTestRoles,
 ):
-    # Arrange
     user = group_transfer.owner_group.get_member_of_role(role_developer_plus)
+    transfer_json = await fetch_transfer_json(client, user.token, group_transfer)
     updated_fields = {
         "name": "New transfer name",
         "is_scheduled": False,
@@ -28,31 +29,14 @@ async def test_developer_plus_can_update_transfer(
         },
     }
 
-    # Act
-    result = await client.patch(
+    result = await client.put(
         f"v1/transfers/{group_transfer.id}",
         headers={"Authorization": f"Bearer {user.token}"},
-        json=updated_fields,
+        json=transfer_json | updated_fields,
     )
 
-    # Assert
     assert result.status_code == 200
-    assert result.json() == {
-        "id": group_transfer.id,
-        "group_id": group_transfer.group_id,
-        "name": updated_fields["name"],
-        "description": group_transfer.description,
-        "schedule": group_transfer.schedule,
-        "is_scheduled": updated_fields["is_scheduled"],
-        "source_connection_id": group_transfer.source_connection_id,
-        "target_connection_id": group_transfer.target_connection_id,
-        "source_params": group_transfer.source_params,
-        "target_params": group_transfer.target_params,
-        "strategy_params": updated_fields["strategy_params"],
-        "transformations": group_transfer.transformations,
-        "resources": updated_fields["resources"],
-        "queue_id": group_transfer.transfer.queue_id,
-    }
+    assert result.json() == build_transfer_json(group_transfer) | updated_fields
 
 
 async def test_groupless_user_cannot_update_transfer(
@@ -60,14 +44,13 @@ async def test_groupless_user_cannot_update_transfer(
     group_transfer: MockTransfer,
     simple_user: MockUser,
 ):
-    # Act
-    result = await client.patch(
+    transfer_json = build_transfer_json(group_transfer)
+    result = await client.put(
         f"v1/transfers/{group_transfer.id}",
         headers={"Authorization": f"Bearer {simple_user.token}"},
-        json={"name": "New transfer name"},
+        json={**transfer_json, "name": "New transfer name"},
     )
 
-    # Assert
     assert result.json() == {
         "error": {
             "code": "not_found",
@@ -83,31 +66,17 @@ async def test_superuser_can_update_transfer(
     group_transfer: MockTransfer,
     superuser: MockUser,
 ):
-    # Act
-    result = await client.patch(
+    updated_fields = {"name": "New transfer name"}
+    transfer_json = await fetch_transfer_json(client, superuser.token, group_transfer)
+
+    result = await client.put(
         f"v1/transfers/{group_transfer.id}",
         headers={"Authorization": f"Bearer {superuser.token}"},
-        json={"name": "New transfer name"},
+        json=transfer_json | updated_fields,
     )
 
-    # Assert
     assert result.status_code == 200
-    assert result.json() == {
-        "id": group_transfer.id,
-        "group_id": group_transfer.group_id,
-        "name": "New transfer name",
-        "description": group_transfer.description,
-        "schedule": group_transfer.schedule,
-        "is_scheduled": group_transfer.is_scheduled,
-        "source_connection_id": group_transfer.source_connection_id,
-        "target_connection_id": group_transfer.target_connection_id,
-        "source_params": group_transfer.source_params,
-        "target_params": group_transfer.target_params,
-        "strategy_params": group_transfer.strategy_params,
-        "transformations": group_transfer.transformations,
-        "resources": group_transfer.resources,
-        "queue_id": group_transfer.transfer.queue_id,
-    }
+    assert result.json() == build_transfer_json(group_transfer) | updated_fields
 
 
 async def test_other_group_member_cannot_update_transfer(
@@ -116,17 +85,15 @@ async def test_other_group_member_cannot_update_transfer(
     group_transfer: MockTransfer,
     role_developer_plus: UserTestRoles,
 ):
-    # Arrange
     user = group.get_member_of_role(role_developer_plus)
+    transfer_json = build_transfer_json(group_transfer)
 
-    # Act
-    result = await client.patch(
+    result = await client.put(
         f"v1/transfers/{group_transfer.id}",
         headers={"Authorization": f"Bearer {user.token}"},
-        json={"name": "New transfer name"},
+        json=transfer_json,
     )
 
-    # Assert
     assert result.json() == {
         "error": {
             "code": "not_found",
@@ -142,17 +109,15 @@ async def test_check_name_field_validation_on_update_transfer(
     group_transfer: MockTransfer,
     role_developer_plus: UserTestRoles,
 ):
-    # Arrange
     user = group_transfer.owner_group.get_member_of_role(role_developer_plus)
+    transfer_json = await fetch_transfer_json(client, user.token, group_transfer)
 
-    # Act
-    result = await client.patch(
+    result = await client.put(
         f"v1/transfers/{group_transfer.id}",
         headers={"Authorization": f"Bearer {user.token}"},
-        json={"name": ""},
+        json={**transfer_json, "name": ""},
     )
 
-    # Assert
     assert result.json() == {
         "error": {
             "code": "invalid_request",
@@ -175,19 +140,22 @@ async def test_check_connection_types_and_its_params_transfer(
     group_transfer: MockTransfer,
     role_developer_plus: UserTestRoles,
 ):
-    # Arrange
     user = group_transfer.owner_group.get_member_of_role(role_developer_plus)
-    # Act
-    result = await client.patch(
+    transfer_json = await fetch_transfer_json(client, user.token, group_transfer)
+    updated_fields = {
+        "name": "New transfer name",
+        "source_params": {
+            "type": "oracle",
+            "table_name": "New table name",
+        },
+    }
+
+    result = await client.put(
         f"v1/transfers/{group_transfer.id}",
         headers={"Authorization": f"Bearer {user.token}"},
-        json={
-            "name": "New transfer name",
-            "source_params": {"type": "oracle", "table_name": "New table name"},
-        },
+        json=transfer_json | updated_fields,
     )
 
-    # Assert
     assert result.status_code == 400
     assert result.json() == {
         "error": {
@@ -197,36 +165,14 @@ async def test_check_connection_types_and_its_params_transfer(
         },
     }
 
-    # Act
-    result = await client.patch(
+    updated_fields["source_params"]["type"] = "postgres"
+    result = await client.put(
         f"v1/transfers/{group_transfer.id}",
         headers={"Authorization": f"Bearer {user.token}"},
-        json={
-            "name": "New transfer name",
-            "source_params": {"type": "postgres", "table_name": "New table name"},
-        },
+        json=transfer_json | updated_fields,
     )
 
-    # Assert
-    assert result.json() == {
-        "id": group_transfer.id,
-        "group_id": group_transfer.group_id,
-        "name": "New transfer name",
-        "description": group_transfer.description,
-        "schedule": group_transfer.schedule,
-        "is_scheduled": group_transfer.is_scheduled,
-        "source_connection_id": group_transfer.source_connection_id,
-        "target_connection_id": group_transfer.target_connection_id,
-        "source_params": {
-            "type": group_transfer.source_params["type"],
-            "table_name": "New table name",
-        },
-        "target_params": group_transfer.target_params,
-        "strategy_params": group_transfer.strategy_params,
-        "transformations": group_transfer.transformations,
-        "resources": group_transfer.resources,
-        "queue_id": group_transfer.transfer.queue_id,
-    }
+    assert result.json() == build_transfer_json(group_transfer) | updated_fields
     assert result.status_code == 200
 
 
@@ -235,18 +181,16 @@ async def test_check_different_connection_groups_for_transfer(
     group_transfer_and_group_connection_developer_plus,
     group_transfer: MockTransfer,
 ):
-    # Arrange
     role, connection = group_transfer_and_group_connection_developer_plus
     user = group_transfer.owner_group.get_member_of_role(role)
+    transfer_json = await fetch_transfer_json(client, user.token, group_transfer)
 
-    # Act
-    result = await client.patch(
+    result = await client.put(
         f"v1/transfers/{group_transfer.id}",
         headers={"Authorization": f"Bearer {user.token}"},
-        json={"source_connection_id": connection.id},
+        json={**transfer_json, "source_connection_id": connection.id},
     )
 
-    # Assert
     assert result.json() == {
         "error": {
             "code": "bad_request",
@@ -263,17 +207,15 @@ async def test_check_different_queue_groups_for_transfer(
     group_transfer: MockTransfer,
     role_developer_plus: UserTestRoles,
 ):
-    # Arrange
     user = group_transfer.owner_group.get_member_of_role(role_developer_plus)
+    transfer_json = await fetch_transfer_json(client, user.token, group_transfer)
 
-    # Act
-    result = await client.patch(
+    result = await client.put(
         f"v1/transfers/{group_transfer.id}",
         headers={"Authorization": f"Bearer {user.token}"},
-        json={"new_queue_id": group_queue.id},
+        json={**transfer_json, "queue_id": group_queue.id},
     )
 
-    # Assert
     assert result.json() == {
         "error": {
             "code": "bad_request",
@@ -290,17 +232,15 @@ async def test_developer_plus_not_in_new_connection_group_cannot_update_transfer
     group_connection: MockConnection,
     role_developer_plus: UserTestRoles,
 ):
-    # Assert
     user = group_transfer.owner_group.get_member_of_role(role_developer_plus)
+    transfer_json = await fetch_transfer_json(client, user.token, group_transfer)
 
-    # Act
-    result = await client.patch(
+    result = await client.put(
         f"v1/transfers/{group_transfer.id}",
         headers={"Authorization": f"Bearer {user.token}"},
-        json={"source_connection_id": group_connection.connection.id},
+        json={**transfer_json, "source_connection_id": group_connection.connection.id},
     )
 
-    # Arrange
     assert result.json() == {
         "error": {
             "code": "not_found",
@@ -315,13 +255,13 @@ async def test_unauthorized_user_cannot_update_transfer(
     client: AsyncClient,
     group_transfer: MockTransfer,
 ):
-    # Act
-    result = await client.patch(
+    transfer_json = build_transfer_json(group_transfer)
+
+    result = await client.put(
         f"v1/transfers/{group_transfer.id}",
-        json={"name": "New transfer name"},
+        json={**transfer_json, "name": "New transfer name"},
     )
 
-    # Assert
     assert result.status_code == 401
     assert result.json() == {
         "error": {
@@ -338,17 +278,15 @@ async def test_developer_plus_cannot_update_transfer_with_other_group_queue(
     role_developer_plus: UserTestRoles,
     group_queue: Queue,
 ):
-    # Arrange
     user = group_transfer.owner_group.get_member_of_role(role_developer_plus)
+    transfer_json = await fetch_transfer_json(client, user.token, group_transfer)
 
-    # Act
-    result = await client.patch(
+    result = await client.put(
         f"v1/transfers/{group_transfer.id}",
         headers={"Authorization": f"Bearer {user.token}"},
-        json={"new_queue_id": group_queue.id},
+        json={**transfer_json, "queue_id": group_queue.id},
     )
 
-    # Assert
     assert result.json() == {
         "error": {
             "code": "bad_request",
@@ -365,14 +303,14 @@ async def test_superuser_cannot_update_transfer_with_other_group_queue(
     superuser: MockUser,
     group_queue: Queue,
 ):
-    # Act
-    result = await client.patch(
+    transfer_json = await fetch_transfer_json(client, superuser.token, group_transfer)
+
+    result = await client.put(
         f"v1/transfers/{group_transfer.id}",
         headers={"Authorization": f"Bearer {superuser.token}"},
-        json={"new_queue_id": group_queue.id},
+        json={**transfer_json, "queue_id": group_queue.id},
     )
 
-    # Assert
     assert result.json() == {
         "error": {
             "code": "bad_request",
@@ -383,22 +321,20 @@ async def test_superuser_cannot_update_transfer_with_other_group_queue(
     assert result.status_code == 400
 
 
-async def test_group_member_cannot_update_unknow_transfer_error(
+async def test_group_member_cannot_update_unknown_transfer_error(
     client: AsyncClient,
     group_transfer: MockTransfer,
     role_guest_plus: UserTestRoles,
 ):
-    # Arrange
     user = group_transfer.owner_group.get_member_of_role(role_guest_plus)
+    transfer_json = await fetch_transfer_json(client, user.token, group_transfer)
 
-    # Act
-    result = await client.patch(
+    result = await client.put(
         "v1/transfers/-1",
         headers={"Authorization": f"Bearer {user.token}"},
-        json={"name": "New transfer name"},
+        json={**transfer_json, "name": "New transfer name"},
     )
 
-    # Assert
     assert result.json() == {
         "error": {
             "code": "not_found",
@@ -414,14 +350,14 @@ async def test_superuser_cannot_update_unknown_transfer_error(
     group_transfer: MockTransfer,
     superuser: MockUser,
 ):
-    # Act
-    result = await client.patch(
+    transfer_json = await fetch_transfer_json(client, superuser.token, group_transfer)
+
+    result = await client.put(
         "v1/transfers/-1",
         headers={"Authorization": f"Bearer {superuser.token}"},
-        json={"name": "New transfer name"},
+        json={**transfer_json, "name": "New transfer name"},
     )
 
-    # Assert
     assert result.json() == {
         "error": {
             "code": "not_found",
@@ -437,17 +373,15 @@ async def test_developer_plus_cannot_update_transfer_with_unknown_queue_id_error
     group_transfer: MockTransfer,
     role_developer_plus: UserTestRoles,
 ):
-    # Arrange
     user = group_transfer.owner_group.get_member_of_role(role_developer_plus)
+    transfer_json = await fetch_transfer_json(client, user.token, group_transfer)
 
-    # Act
-    result = await client.patch(
+    result = await client.put(
         f"v1/transfers/{group_transfer.id}",
         headers={"Authorization": f"Bearer {user.token}"},
-        json={"new_queue_id": -1},
+        json={**transfer_json, "queue_id": -1},
     )
 
-    # Assert
     assert result.json() == {
         "error": {
             "code": "not_found",
@@ -463,14 +397,14 @@ async def test_superuser_cannot_update_transfer_with_unknown_queue_id(
     group_transfer: MockTransfer,
     superuser: MockUser,
 ):
-    # Act
-    result = await client.patch(
+    transfer_json = await fetch_transfer_json(client, superuser.token, group_transfer)
+
+    result = await client.put(
         f"v1/transfers/{group_transfer.id}",
         headers={"Authorization": f"Bearer {superuser.token}"},
-        json={"new_queue_id": -1},
+        json={**transfer_json, "queue_id": -1},
     )
 
-    # Assert
     assert result.json() == {
         "error": {
             "code": "not_found",


### PR DESCRIPTION
## Change Summary

Replaced `PATCH` with `PUT` for `Connection` and `Transfer` models due to their nested structures.

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.