### PR TITLE
[DOP-22297] Parallel reading from JDBC sources

### DIFF
--- a/docs/changelog/next_release/219.improvement.rst
+++ b/docs/changelog/next_release/219.improvement.rst
@@ -1,0 +1,1 @@
+Enable parallel reading from JDBC sources

--- a/syncmaster/dto/transfers.py
+++ b/syncmaster/dto/transfers.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 
 from onetl.file.format import CSV, JSON, ORC, XML, Excel, JSONLine, Parquet
 
+from syncmaster.dto.transfers_resources import Resources
 from syncmaster.dto.transfers_strategy import FullStrategy, IncrementalStrategy
 
 
@@ -19,6 +20,7 @@ class DBTransferDTO(TransferDTO):
     id: int
     table_name: str
     strategy: FullStrategy | IncrementalStrategy
+    resources: Resources
     transformations: list[dict] | None = None
     options: dict | None = None
 
@@ -34,6 +36,7 @@ class FileTransferDTO(TransferDTO):
     directory_path: str
     file_format: CSV | JSONLine | JSON | Excel | XML | ORC | Parquet
     strategy: FullStrategy | IncrementalStrategy
+    resources: Resources
     options: dict
     file_name_template: str | None = None
     df_schema: dict | None = None

--- a/syncmaster/dto/transfers_resources.py
+++ b/syncmaster/dto/transfers_resources.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2023-2024 MTS PJSC
+# SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass
+
+
+@dataclass
+class Resources:
+    max_parallel_tasks: int
+    cpu_cores_per_task: int
+    ram_bytes_per_task: int

--- a/syncmaster/worker/controller.py
+++ b/syncmaster/worker/controller.py
@@ -41,6 +41,7 @@ from syncmaster.dto.transfers import (
     SFTPTransferDTO,
     WebDAVTransferDTO,
 )
+from syncmaster.dto.transfers_resources import Resources
 from syncmaster.dto.transfers_strategy import Strategy
 from syncmaster.exceptions.connection import ConnectionTypeNotRecognizedError
 from syncmaster.schemas.v1.connection_types import FILE_CONNECTION_TYPES
@@ -169,6 +170,7 @@ class TransferController:
             transfer_id=run.transfer.id,
             transfer_params=run.transfer.source_params,
             strategy_params=run.transfer.strategy_params,
+            resources=run.transfer.resources,
             transformations=run.transfer.transformations,
             connection_auth_data=source_auth_data,
             temp_dir=TemporaryDirectory(dir=self.temp_dir.name, prefix="downloaded_"),
@@ -179,6 +181,7 @@ class TransferController:
             transfer_id=run.transfer.id,
             transfer_params=run.transfer.target_params,
             strategy_params=run.transfer.strategy_params,
+            resources=run.transfer.resources,
             transformations=run.transfer.transformations,
             connection_auth_data=target_auth_data,
             temp_dir=TemporaryDirectory(dir=self.temp_dir.name, prefix="written_"),
@@ -215,6 +218,7 @@ class TransferController:
         transfer_id: int,
         transfer_params: dict[str, Any],
         strategy_params: dict[str, Any],
+        resources: dict[str, Any],
         transformations: list[dict],
         temp_dir: TemporaryDirectory,
     ) -> Handler:
@@ -232,6 +236,7 @@ class TransferController:
             transfer_dto=transfer_dto(
                 id=transfer_id,
                 strategy=Strategy.from_dict(strategy_params),
+                resources=Resources(**resources),
                 transformations=transformations,
                 **transfer_params,
             ),

--- a/syncmaster/worker/handlers/db/clickhouse.py
+++ b/syncmaster/worker/handlers/db/clickhouse.py
@@ -46,9 +46,9 @@ class ClickhouseHandler(DBHandler):
             (col for col in normalized_df.columns if col.lower().endswith("id")),
             normalized_df.columns[0],  # if there is no column with "id", take the first column
         )
-        quoted_sort_column = f'"{sort_column}"'
-
-        self.transfer_dto.options["createTableOptions"] = f"ENGINE = MergeTree() ORDER BY {quoted_sort_column}"
+        self.transfer_dto.options["createTableOptions"] = (
+            f"ENGINE = MergeTree() ORDER BY {self._quote_field(sort_column)}"
+        )
 
         if self.transfer_dto.strategy.type == "incremental" and self.hwm and self.hwm.value:
             self.transfer_dto.options["if_exists"] = "append"

--- a/syncmaster/worker/handlers/db/hive.py
+++ b/syncmaster/worker/handlers/db/hive.py
@@ -60,6 +60,9 @@ class HiveHandler(DBHandler):
 
         return " AND ".join(expressions) or None
 
+    def _get_reading_options(self) -> dict:
+        return {}
+
     @staticmethod
     def _quote_field(field):
         return f"`{field}`"

--- a/tests/test_integration/test_run_transfer/test_clickhouse.py
+++ b/tests/test_integration/test_run_transfer/test_clickhouse.py
@@ -47,6 +47,13 @@ async def postgres_to_clickhouse(
             "table_name": f"{clickhouse_for_conftest.user}.target_table",
         },
         strategy_params=strategy,
+        # this covers setting JDBC parallel reading options for full and incremental strategies
+        # TODO: add fixtures if usage increases
+        resources={
+            "max_parallel_tasks": 2,
+            "cpu_cores_per_task": 1,
+            "ram_bytes_per_task": 1024**3,
+        },
         transformations=transformations,
         queue_id=queue.id,
     )


### PR DESCRIPTION
## Change Summary

Enabled parallel reading for JDBC sources:  
- If `max_parallel_tasks == 1`, no changes to reading parameters  
- If `strategy.type == incremental` and HWM exists in `HWMStore`, used `increment_by` column with `partitioning_mode=range`. Efficient for indexed primary key with conditions
- If `strategy.type == incremental` and HWM does not exist, used `increment_by` column with `partitioning_mode=hash`. Full scan is more efficient than index lookup
- If `strategy.type == full`, retrieved the source schema, selected the first column, and used `partitioning_mode=hash`. Works regardless of column type and is efficient for full scans

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.