### PR TITLE
[DOP-22729] Generate log_url on worker side

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -17,9 +17,11 @@ SYNCMASTER__BROKER__URL=amqp://guest:guest@rabbitmq:5672
 
 # Server options
 SYNCMASTER__SERVER__SESSION__SECRET_KEY=generate_some_random_string
-SYNCMASTER__SERVER__LOG_URL_TEMPLATE=https://logs.location.example.com/syncmaster-worker?correlation_id={{ correlation_id }}&run_id={{ run.id }}
 # !!! NEVER USE ON PRODUCTION !!!
 SYNCMASTER__SERVER__DEBUG=true
+
+# Worker options
+SYNCMASTER__WORKER__LOG_URL_TEMPLATE=https://logs.location.example.com/syncmaster-worker?correlation_id={{ correlation_id }}&run_id={{ run.id }}
 
 # Keycloak Auth
 #SYNCMASTER__AUTH__PROVIDER=syncmaster.server.providers.auth.keycloak_provider.KeycloakAuthProvider

--- a/.env.local
+++ b/.env.local
@@ -17,9 +17,11 @@ export SYNCMASTER__BROKER__URL=amqp://guest:guest@localhost:5672
 
 # Server options
 export SYNCMASTER__SERVER__SESSION__SECRET_KEY=generate_some_random_string
-export SYNCMASTER__SERVER__LOG_URL_TEMPLATE="https://logs.location.example.com/syncmaster-worker?correlation_id={{ correlation_id }}&run_id={{ run.id }}"
 # !!! NEVER USE ON PRODUCTION !!!
 export SYNCMASTER__SERVER__DEBUG=true
+
+# Worker options
+export SYNCMASTER__WORKER__LOG_URL_TEMPLATE="https://logs.location.example.com/syncmaster-worker?correlation_id={{ correlation_id }}&run_id={{ run.id }}"
 
 # Keycloak Auth
 #export SYNCMASTER__AUTH__PROVIDER=syncmaster.server.providers.auth.keycloak_provider.KeycloakAuthProvider

--- a/docs/worker/log_url.rst
+++ b/docs/worker/log_url.rst
@@ -3,13 +3,12 @@
 Setting the `Run.log_url` value
 ===============================
 
-Each run in the system is linked to a log URL where the Celery worker logs are available. This log URL might point to an Elastic instance or another logging tool such as Grafana. The log URL is generated based on a template configured in the server.
+Each run in the system is linked to a log URL where the Celery worker logs are available. This log URL might point to an Elastic instance or another logging tool such as Grafana. The log URL is generated based on a template configured in the configuration.
 
 The configuration parameter is:
 
 .. code-block:: bash
 
-  SYNCMASTER__SERVER__LOG_URL_TEMPLATE=https://grafana.example.com?correlation_id={{ correlation_id }}&run_id={{ run.id }}
+  SYNCMASTER__WORKER__LOG_URL_TEMPLATE=https://grafana.example.com?correlation_id={{ correlation_id }}&run_id={{ run.id }}
 
 You can search for each run by either its correlation id ``x-request-id`` in http headers or the ``Run.Id``.
-

--- a/syncmaster/server/api/v1/runs.py
+++ b/syncmaster/server/api/v1/runs.py
@@ -4,10 +4,8 @@ import asyncio
 from datetime import datetime
 from typing import Annotated
 
-from asgi_correlation_id import correlation_id
 from celery import Celery
 from fastapi import APIRouter, Depends, Query
-from jinja2 import Template
 from kombu.exceptions import KombuError
 
 from syncmaster.db.models import RunType, Status, User
@@ -120,15 +118,6 @@ async def start_run(
             source_creds=ReadAuthDataSchema(auth_data=credentials_source).dict(),
             target_creds=ReadAuthDataSchema(auth_data=credentials_target).dict(),
             type=RunType.MANUAL,
-        )
-
-        log_url = Template(settings.server.log_url_template).render(
-            run=run,
-            correlation_id=correlation_id.get(),
-        )
-        run = await unit_of_work.run.update(
-            run_id=run.id,
-            log_url=log_url,
         )
 
     try:

--- a/syncmaster/server/settings/server/__init__.py
+++ b/syncmaster/server/settings/server/__init__.py
@@ -35,10 +35,6 @@ class ServerSettings(BaseModel):
             """,
         ),
     )
-    log_url_template: str = Field(
-        "",
-        description=":ref:`URL template to access worker logs <worker-log-url>`",
-    )
     request_id: RequestIDSettings = Field(
         default_factory=RequestIDSettings,
     )

--- a/syncmaster/worker/settings/__init__.py
+++ b/syncmaster/worker/settings/__init__.py
@@ -22,11 +22,16 @@ class WorkerSettings(BaseSettings):
     .. code-block:: bash
 
         SYNCMASTER__WORKER__CREATE_SPARK_SESSION_FUNCTION=custom_syncmaster.spark.get_worker_spark_session
+        SYNCMASTER__WORKER__LOG_URL_TEMPLATE=https://logs.location.example.com/syncmaster-worker?correlation_id={{ correlation_id }}&run_id={{ run.id }}
     """
 
     CREATE_SPARK_SESSION_FUNCTION: ImportString = Field(
         "syncmaster.worker.spark.get_worker_spark_session",
         description="Function to create Spark session for worker",
+    )
+    log_url_template: str = Field(
+        "",
+        description=":ref:`URL template to access worker logs <worker-log-url>`",
     )
 
 

--- a/tests/test_unit/test_runs/test_create_run.py
+++ b/tests/test_unit/test_runs/test_create_run.py
@@ -157,8 +157,6 @@ async def test_superuser_can_create_run(
         "type": RunType.MANUAL,
     }
     assert result.status_code == 200
-    assert "correlation_id" in response.get("log_url")
-    assert "run_id" in response.get("log_url")
     mock_to_thread.assert_awaited_once_with(
         mock_send_task,
         "run_transfer_task",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -171,6 +171,8 @@ async def run_transfer_and_verify(
         token=user.token,
     )
     assert run_data["status"] == Status.FINISHED.value
+    assert "correlation_id" in run_data["log_url"]
+    assert "run_id" in run_data["log_url"]
     verify_transfer_auth_data(run_data, source_auth, target_auth)
 
     return run_data


### PR DESCRIPTION
## Change Summary

Ensured that `log_url` is always populated on the worker side, even when `Transfer` is started from the scheduler, instead of relying solely on the server.

## Checklist

* [ ] Commit message and PR title is comprehensive
* [ ] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [ ] My PR is ready to review.