### PR TITLE
[DOP-25451] Fix Hive/HDFS connectors ignoring user & password

### DIFF
--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -66,5 +66,13 @@ RUN --mount=type=cache,target=/root/.cache/pypoetry \
         --without docs,dev \
     && python -m compileall -j 4 .venv
 
-RUN sed -i 's/python -m/coverage run -m/g' /app/entrypoint.sh
 ENV SYNCMASTER__WORKER__CREATE_SPARK_SESSION_FUNCTION=tests.spark.get_worker_spark_session
+
+# Collect coverage from worker
+RUN sed -i 's/python -m/coverage run -m/g' /app/entrypoint.sh
+
+# Replace kinit binary with dummy, to skip Kerberos interaction in tests
+RUN mkdir -p /app/.local/bin && \
+    echo "#!/bin/bash" > /app/.local/bin/kinit \
+    && chmod +x /app/.local/bin/kinit
+ENV PATH="/app/.local/bin:$PATH"

--- a/docs/changelog/0.2.2.rst
+++ b/docs/changelog/0.2.2.rst
@@ -1,0 +1,8 @@
+0.2.2 (2025-04-11)
+==================
+
+Bug fixes
+---------
+
+- Call ``kinit`` before starting Spark session conecting to ``Hive`` cluster.
+- Fix ``HDFS`` connection was trying to use anonymous auth instead of user/password.

--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -3,6 +3,7 @@
     :caption: Changelog
 
     DRAFT
+    0.2.2
     0.2.1
     0.2.0
     0.1.5

--- a/syncmaster/worker/handlers/file/hdfs.py
+++ b/syncmaster/worker/handlers/file/hdfs.py
@@ -25,4 +25,6 @@ class HDFSHandler(RemoteDFFileHandler):
 
         self.file_connection = HDFS(
             cluster=self.connection_dto.cluster,
+            user=self.connection_dto.user,
+            password=self.connection_dto.password,
         ).check()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Now `HDFS` and `Hive` connection types call `kinit` before creating Spark session. `HDFS` connection uses KerberosClient instead of InsecureClient.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/syncmaster/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.